### PR TITLE
docs: migrate protocol and development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,34 @@ WatcheRobot-Firmware/
 
 ## Documentation
 
+### Getting Started
+
 | Document | Description |
 |----------|-------------|
 | [docs/getting-started.md](docs/getting-started.md) | Full setup guide |
+| [docs/roadmap.md](docs/roadmap.md) | Development phases and milestones |
+
+### Architecture & Design
+
+| Document | Description |
+|----------|-------------|
 | [docs/architecture.md](docs/architecture.md) | System architecture & component design |
 | [docs/hardware/gpio-mapping.md](docs/hardware/gpio-mapping.md) | GPIO pin assignment |
+| [docs/hardware/bom.md](docs/hardware/bom.md) | Bill of materials |
+
+### Protocols
+
+| Document | Description |
+|----------|-------------|
+| [docs/protocol/websocket-protocol.md](docs/protocol/websocket-protocol.md) | WebSocket protocol v2.3 |
+| [docs/protocol/voice-stream.md](docs/protocol/voice-stream.md) | Audio streaming specification |
+
+### Development
+
+| Document | Description |
+|----------|-------------|
+| [docs/development/known-issues.md](docs/development/known-issues.md) | Known issues & workarounds |
+| [docs/development/testing.md](docs/development/testing.md) | Testing guide |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
 | [CHANGELOG.md](CHANGELOG.md) | Version history |
 

--- a/docs/development/known-issues.md
+++ b/docs/development/known-issues.md
@@ -1,0 +1,224 @@
+# Known Issues & Technical Notes
+
+> Documented issues, workarounds, and technical decisions
+
+---
+
+## 1. AFE Ringbuffer Priority Sync Issue
+
+### Status
+**OPEN** — Partially mitigated, may still occur under load
+
+### Description
+
+ESP-SR AFE (Audio Front-End) ringbuffer has write/read timing sync issues regardless of `detection_task` priority:
+
+| detection_task Priority | Symptom | Cause |
+|------------------------|---------|-------|
+| 4 (below voice_task) | Ringbuffer Full | voice_task writes too fast, detection_task can't fetch() |
+| 5 (equal to voice_task) | Uncertain | Depends on task scheduling |
+| 6 (above voice_task) | Ringbuffer Empty | detection_task reads too fast, voice_task can't feed() |
+
+### Root Cause
+
+Task execution rate mismatch:
+
+1. **voice_recorder_task**: Executes every 60ms, reads one audio frame and feeds AFE
+2. **detection_task**: Each fetch() consumes one frame, but execution timing is unpredictable
+
+When detection_task priority > voice_task:
+- detection_task immediately executes fetch()
+- But voice_task hasn't executed feed() yet
+- Result: ringbuffer empty
+
+When detection_task priority < voice_task:
+- voice_task continuously feeds data
+- detection_task doesn't get enough CPU time to read
+- Result: ringbuffer full
+
+### Attempted Fixes
+
+#### Fix 1: Adjust Priority (FAILED)
+
+| Priority Config | Result |
+|-----------------|--------|
+| detection=4, voice=5 | Ringbuffer Full |
+| detection=5, voice=5 | Uncertain |
+| detection=6, voice=5 | Ringbuffer Empty |
+
+#### Fix 2: Add Startup Delay (PARTIAL)
+
+Added 100ms delay in `hal_wake_word_start()`:
+- First startup can buffer a few frames
+- Still has timing issues after stable operation
+
+### Proposed Solutions
+
+#### Option A: Semaphore Sync
+
+```c
+SemaphoreHandle_t feed_done_sem = xSemaphoreCreateBinary();
+
+// In voice_recorder_task, after feed()
+void hal_wake_word_feed(...) {
+    // ... feed data
+    xSemaphoreGive(feed_done_sem);
+}
+
+// In detection_task
+void detection_task(void *arg) {
+    while (1) {
+        xSemaphoreTake(feed_done_sem, portMAX_DELAY);
+        afe_fetch_result_t *res = ctx->afe_iface->fetch(ctx->afe_data);
+        // ... process result
+    }
+}
+```
+
+**Drawback**: Per-frame semaphore adds overhead
+
+#### Option B: Sync fetch() in feed()
+
+Call fetch() immediately after feed() in same task:
+
+```c
+void hal_wake_word_feed(wake_word_ctx_t *ctx, const int16_t *samples, size_t num_samples) {
+    // ... feed data
+
+    // Immediately fetch to ensure data is consumed
+    while (ctx->afe_iface->get_feed_chunksize(ctx->afe_data) <= ctx->input_buffer_size) {
+        afe_fetch_result_t *res = ctx->afe_iface->fetch(ctx->afe_data);
+        if (res && res->wakeup_state == WAKENET_DETECTED) {
+            // Handle wake word detection
+        }
+    }
+}
+```
+
+**Drawback**: May block voice_recorder_task, needs testing
+
+#### Option C: Increase AFE Ringbuffer
+
+Modify ESP-SR library to increase buffer size. May not be feasible without ESP support.
+
+#### Option D: Lower voice_recorder_task Priority
+
+Reduce from 5 to 4, giving detection_task (6) CPU time first.
+
+**Status**: Not tested
+
+#### Option E: Use Queue Instead
+
+Create FreeRTOS queue, voice_recorder_task puts audio data in queue, detection_task retrieves:
+
+```c
+QueueHandle_t audio_queue = xQueueCreate(10, sizeof(audio_frame_t));
+
+// voice_recorder_task
+xQueueSend(audio_queue, &frame, 0);
+
+// detection_task
+if (xQueueReceive(audio_queue, &frame, 0)) {
+    ctx->afe_iface->feed(ctx->afe_data, frame.samples);
+    // Also fetch
+}
+```
+
+**Drawback**: Adds complexity and latency
+
+### Current Workaround
+
+```c
+// Current config in hal_wake_word.c
+#define DETECTION_TASK_PRIO    6  // High priority
+#define DETECTION_TASK_STACK   4096
+
+// 100ms startup delay in hal_wake_word_start()
+void hal_wake_word_start(wake_word_ctx_t *ctx) {
+    xEventGroupSetBits(ctx->event_group, DETECTION_RUNNING_BIT);
+    vTaskDelay(pdMS_TO_TICKS(100));  // Startup delay
+    ESP_LOGI(TAG, "Wake word detection started");
+}
+```
+
+### Related Files
+
+- `components/services/voice_service/src/hal_wake_word.c`
+- `components/services/voice_service/src/voice_fsm.c`
+- `components/hal/hal_audio/src/hal_audio.c`
+
+### References
+
+- ESP-SR: https://github.com/espressif/esp-sr
+- AFE API: `esp_afe_sr_iface_t`
+
+---
+
+## 2. LVGL PNG Decoder Memory
+
+### Status
+**RESOLVED** (v1.5.0)
+
+### Problem
+
+PNG images displayed as white/blank screen.
+
+### Root Cause
+
+1. `CONFIG_LV_USE_PNG` not enabled
+2. Wrong image format: `LV_IMG_CF_TRUE_COLOR_ALPHA` instead of `LV_IMG_CF_RAW_ALPHA`
+3. LVGL memory too small: 32KB insufficient for 412×412 RGBA (678KB)
+
+### Solution
+
+```c
+// CORRECT - tells LVGL "this is PNG data, please decode"
+img_dsc->header.cf = LV_IMG_CF_RAW_ALPHA;
+```
+
+Enable in sdkconfig:
+- `CONFIG_LV_USE_PNG=y`
+- `CONFIG_LV_MEM_CUSTOM=y` (use PSRAM)
+
+### Lesson Learned
+
+When using LVGL with PNG:
+1. Enable `CONFIG_LV_USE_PNG`
+2. Use `LV_IMG_CF_RAW_ALPHA` for PNG data
+3. Use `LV_MEM_CUSTOM` with PSRAM for large images
+
+---
+
+## 3. SPI Transmit Conflict
+
+### Status
+**RESOLVED** (v1.4.0)
+
+### Problem
+
+LCD SPI transmit failed with:
+```
+E (10642) lcd_panel.io.spi: panel_io_spi_tx_color(390): spi transmit (queue) color failed
+```
+
+### Root Cause
+
+WiFi DMA buffers consumed internal memory needed by LCD SPI.
+
+### Solution
+
+Sync sdkconfig with factory_firmware:
+- `CONFIG_SPIRAM_SPEED_80M=y` (was 40MHz)
+- `CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y`
+- `CONFIG_ESP32S3_DATA_CACHE_SIZE_32KB=y`
+- `CONFIG_SPI_MASTER_IN_IRAM=y`
+
+---
+
+## Changelog
+
+| Date | Issue | Status |
+|------|-------|--------|
+| 2026-03-11 | AFE Ringbuffer Priority | OPEN |
+| 2026-03-04 | LVGL PNG Memory | RESOLVED |
+| 2026-02-28 | SPI Transmit Conflict | RESOLVED |

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,180 @@
+# Testing Guide
+
+> Integration testing and quality assurance for WatcheRobot
+
+---
+
+## 1. Test Categories
+
+| Category | Scope | Tools |
+|----------|-------|-------|
+| **Unit Tests** | Individual components | Unity (ESP-IDF built-in) |
+| **Host Tests** | Pure logic modules | CMake + MinGW |
+| **Integration Tests** | Multi-component flows | Manual + Automation |
+| **E2E Tests** | Full system | Hardware-in-loop |
+
+---
+
+## 2. Unit Tests
+
+### 2.1 Component Test Structure
+
+```
+my_component/
+└── test_apps/
+    └── main/
+        ├── CMakeLists.txt
+        └── test_my_component.c
+```
+
+### 2.2 Running Unit Tests
+
+```bash
+# In ESP-IDF environment
+cd firmware/s3/components/hal/hal_servo/test_apps
+idf.py -p COM3 flash monitor
+```
+
+### 2.3 Test Coverage
+
+Each component should have tests for:
+- Init/deinit lifecycle
+- Public API functions
+- Edge cases and error handling
+
+---
+
+## 3. Host Tests (PC)
+
+For pure logic modules without hardware dependencies:
+
+```bash
+# Run host tests
+cd firmware/s3/test_host
+cmake -B build -G "MinGW Makefiles"
+cmake --build build
+ctest --test-dir build -V
+```
+
+---
+
+## 4. Integration Tests
+
+### 4.1 Connection Test
+
+| # | Test | Expected | Status |
+|---|------|----------|--------|
+| 1.1 | ESP32-S3 WebSocket connect | Log: "WebSocket connected" | ⬜ |
+| 1.2 | Display happy emoji | After connection success | ⬜ |
+| 1.3 | UDP discovery | Server responds with IP:port | ⬜ |
+
+### 4.2 Audio Flow Test
+
+| # | Test | Expected | Status |
+|---|------|----------|--------|
+| 2.1 | Button long press → recording | Display "Listening..." | ⬜ |
+| 2.2 | Send Raw PCM 16kHz | Server receives audio | ⬜ |
+| 2.3 | Button release → audio_end | Server acknowledges | ⬜ |
+| 2.4 | Receive asr_result | Display recognized text | ⬜ |
+| 2.5 | Receive bot_reply | Display AI response | ⬜ |
+| 2.6 | Receive TTS audio | Play Raw PCM 24kHz | ⬜ |
+| 2.7 | tts_end received | Resume wake word | ⬜ |
+
+### 4.3 Wake Word Test
+
+| # | Test | Expected | Status |
+|---|------|----------|--------|
+| 3.1 | Say "Hi 乐鑫" | Wake word detected | ⬜ |
+| 3.2 | Auto-start recording | VAD silence detection | ⬜ |
+| 3.3 | Continuous conversation | Works after TTS end | ⬜ |
+
+### 4.4 Servo Control Test
+
+| # | Test | Expected | Status |
+|---|------|----------|--------|
+| 4.1 | servo X:90 | GPIO 19 PWM output | ⬜ |
+| 4.2 | servo Y:120 | GPIO 20 PWM output | ⬜ |
+| 4.3 | Smooth move | 500ms transition | ⬜ |
+| 4.4 | Y-axis limit | 90–150° range enforced | ⬜ |
+
+### 4.5 Display Test
+
+| # | Test | Expected | Status |
+|---|------|----------|--------|
+| 5.1 | Animation playback | 30fps smooth | ⬜ |
+| 5.2 | Emoji switch | < 100ms transition | ⬜ |
+| 5.3 | Text display | Correct rendering | ⬜ |
+
+---
+
+## 5. Protocol Alignment
+
+### 5.1 Audio Stream Protocol ✅ Aligned
+
+| Feature | Server | Device | Status |
+|---------|--------|--------|--------|
+| Audio upload | Raw PCM | Raw PCM | ✅ |
+| Recording end | `{"type":"audio_end"}` | Same | ✅ |
+| ASR result | `{"type":"asr_result",...}` | Same | ✅ |
+| TTS audio | Raw PCM 24kHz | Same | ✅ |
+| Error | `{"type":"error",...}` | Same | ✅ |
+
+### 5.2 Servo Protocol ✅ Aligned
+
+| Feature | Server | Device | Status |
+|---------|--------|--------|--------|
+| Servo move | `{"type":"servo","data":{...}}` | GPIO PWM | ✅ |
+| X-axis | 0–180° | GPIO 19 | ✅ |
+| Y-axis | 90–150° | GPIO 20 | ✅ |
+
+---
+
+## 6. Test Environment
+
+| Item | Value |
+|------|-------|
+| Server IP | `192.168.31.10` (or via discovery) |
+| WebSocket Port | 8766 |
+| UDP Discovery Port | 8767 |
+| ESP32-S3 Port | COM3 (Windows) / /dev/ttyUSB0 (Linux) |
+
+### Server Configuration
+
+```bash
+# watcher-server/.env
+WS_PORT=8766
+UDP_PORT=8767
+```
+
+---
+
+## 7. Regression Checklist
+
+Before each release:
+
+- [ ] All unit tests pass
+- [ ] Integration tests pass
+- [ ] Wake word detection works
+- [ ] Button recording works
+- [ ] TTS playback works
+- [ ] Servo control works
+- [ ] Animation smooth at 30fps
+- [ ] OTA update tested
+- [ ] Memory stable (no leaks after 1hr)
+
+---
+
+## 8. Performance Benchmarks
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| Wake word latency | < 500ms | ⬜ |
+| ASR → LLM → TTS | < 3s | ⬜ |
+| Animation FPS | 30 | ⬜ |
+| Servo smooth move | 10ms step | ⬜ |
+| PSRAM usage (anim) | < 6MB | ⬜ |
+| Boot time | < 3s | ⬜ |
+
+---
+
+*Last updated: 2026-03-11*

--- a/docs/protocol/voice-stream.md
+++ b/docs/protocol/voice-stream.md
@@ -1,0 +1,209 @@
+# Voice Stream Protocol v2.0
+
+> Audio streaming specification for WatcheRobot
+> Version: 2.0 | Date: 2026-03-11
+
+See also: [WebSocket Protocol](websocket-protocol.md) for full protocol details.
+
+---
+
+## 1. Audio Format
+
+| Parameter | Recording (ASR) | Playback (TTS) |
+|-----------|-----------------|----------------|
+| Format | PCM (Raw Binary) | PCM (Raw Binary) |
+| Sample Rate | 16000 Hz | 24000 Hz |
+| Bit Depth | 16-bit signed | 16-bit signed |
+| Channels | Mono | Mono |
+| Endianness | Little-endian | Little-endian |
+| Frame Size | 1920 bytes (60ms) | Variable |
+
+**Bandwidth**:
+- Upload: 256 kbps
+- Download: 384 kbps
+
+---
+
+## 2. Device → Server
+
+### 2.1 Audio Data (Binary)
+
+```
+WebSocket Binary Frame
+┌─────────────────────────┐
+│   Raw PCM Data (N B)    │
+│   16kHz, 16-bit, mono  │
+└─────────────────────────┘
+```
+
+No header — raw PCM samples only.
+
+### 2.2 Recording End (JSON)
+
+```json
+{"type": "audio_end"}
+```
+
+### 2.3 Status Report
+
+```json
+{"type": "status", "state": "listening" | "recording" | "thinking" | "speaking" | "idle" | "error"}
+```
+
+---
+
+## 3. Server → Device
+
+### 3.1 ASR Result
+
+```json
+{"type": "asr_result", "code": 0, "data": "recognized text"}
+```
+
+### 3.2 Bot Reply
+
+```json
+{"type": "bot_reply", "code": 0, "data": "AI response"}
+```
+
+### 3.3 TTS Start
+
+```json
+{"type": "status", "state": "speaking"}
+```
+
+### 3.4 TTS Audio (Binary)
+
+```
+WebSocket Binary Frame
+┌─────────────────────────┐
+│   Raw PCM Data (N B)    │
+│   24kHz, 16-bit, mono  │
+└─────────────────────────┘
+```
+
+### 3.5 TTS End
+
+```json
+{"type": "tts_end", "code": 0, "data": "ok"}
+```
+
+### 3.6 Error
+
+```json
+{"type": "error", "code": 1, "data": "error description"}
+```
+
+---
+
+## 4. Complete Flow
+
+```
+[S3 Device]                              [Cloud Server]
+     │                                        │
+     │  1. Wake word detected / Button press  │
+     │                                        │
+     │  2. Raw PCM chunks (16kHz)            │
+     │  ─────────────────────►                │
+     │                                        │
+     │  3. {"type": "audio_end"}              │
+     │  ─────────────────────►                │
+     │                                        │
+     │                    4. ASR recognition  │
+     │  ◄─────────────────────                │
+     │     {"type": "asr_result", ...}        │
+     │                                        │
+     │                    5. LLM processing   │
+     │                                        │
+     │  6. {"type": "bot_reply", ...}         │
+     │  ◄─────────────────────                │
+     │                                        │
+     │  7. {"type": "status", "speaking"}     │
+     │  ◄─────────────────────                │
+     │                                        │
+     │  8. TTS audio stream (24kHz)           │
+     │  ◄─────────────────────                │
+     │     Raw PCM chunks                     │
+     │                                        │
+     │  9. {"type": "tts_end"}                │
+     │  ◄─────────────────────                │
+     │                                        │
+     │  10. Resume wake word detection        │
+     │                                        │
+     ▼                                        ▼
+```
+
+---
+
+## 5. Device Implementation
+
+### 5.1 Sending Audio
+
+```c
+// components/protocols/ws_client/src/ws_client.c
+
+// Send PCM data
+ws_send_audio(pcm_data, len);
+
+// Send end marker
+ws_send_audio_end();
+
+// Send status report
+ws_send_status("recording");
+```
+
+### 5.2 Receiving Handler
+
+```c
+// Handle JSON text messages
+void ws_handle_text(const char *msg) {
+    cJSON *root = cJSON_Parse(msg);
+    const char *type = cJSON_GetObjectItem(root, "type")->valuestring;
+
+    if (strcmp(type, "asr_result") == 0) {
+        // Display recognition result
+    }
+    else if (strcmp(type, "tts_end") == 0) {
+        // TTS playback complete, resume wake word
+        voice_recorder_resume_wake_word();
+    }
+    else if (strcmp(type, "status") == 0) {
+        // State update
+    }
+}
+
+// Handle binary TTS audio
+void ws_handle_tts_binary(const uint8_t *data, int len) {
+    hal_audio_write(data, len);  // Direct write Raw PCM 24kHz
+}
+```
+
+---
+
+## 6. Wake Word Mode
+
+### 6.1 Detection Flow
+
+1. `hal_wake_word_init()` — Initialize AFE model
+2. `voice_recorder_task` — Poll and feed PCM data
+3. Wake word "Hi 乐鑫" detected
+4. Trigger callback `on_wake_word_detected()`
+5. Start recording, enable VAD silence detection
+
+### 6.2 VAD Silence Detection
+
+- Silence timeout: 1500ms (default)
+- RMS threshold: 100
+- Minimum speech: 300ms
+
+---
+
+## 7. Service Discovery
+
+- UDP broadcast port: 8767
+- WebSocket port: 8766
+
+---
+
+*Version 2.0 — Compatible with watcher-server v2.0*
+*See COMMUNICATION_PROTOCOL.md for complete protocol details*

--- a/docs/protocol/websocket-protocol.md
+++ b/docs/protocol/websocket-protocol.md
@@ -1,0 +1,443 @@
+# WebSocket Protocol v2.3
+
+> WatcheRobot Firmware communication protocol
+> Version: 2.3 | Date: 2026-03-11
+
+---
+
+## 1. System Architecture
+
+```
+┌─────────────────────────────┐      WebSocket (WiFi)      ┌─────────────────────────────┐
+│      WatcheRobot (S3)       │◄──────────────────────────►│        Cloud Server         │
+│         ESP32-S3            │     ws://IP:8766           │       Python Server         │
+├─────────────────────────────┤                            ├─────────────────────────────┤
+│ • Audio capture/playback    │                            │ • ASR (Aliyun)              │
+│ • LVGL display + animation  │                            │ • LLM (Claude API)          │
+│ • Wake word detection       │                            │ • TTS (Volcengine)          │
+│ • Servo control (GPIO PWM)  │                            │ • Agent orchestration       │
+│ • Camera streaming          │                            │ • OTA management            │
+└─────────────────────────────┘                            └─────────────────────────────┘
+```
+
+**Key Changes from v2.x**:
+- MCU removed — servo control via GPIO 19/20 LEDC PWM (no UART)
+- Camera streaming support added
+- OTA firmware update support added
+
+---
+
+## 2. Message Format
+
+### 2.1 JSON Text Messages
+
+All JSON messages use unified format:
+
+```json
+{
+  "type": "message_type",
+  "code": 0,
+  "data": "payload"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| type | string | Message type identifier |
+| code | int | Status code: `0` = success, `1` = error |
+| data | any | Payload (string, object, array, etc.) |
+
+### 2.2 Binary Messages
+
+| Direction | Format | Description |
+|-----------|--------|-------------|
+| Device → Server | Raw PCM 16kHz 16-bit mono | Voice audio |
+| Server → Device | Raw PCM 24kHz 16-bit mono | TTS audio |
+| Device → Server | WVID frame (see §5) | Camera video |
+
+---
+
+## 3. Server → Device Messages
+
+### 3.1 ASR Result (`asr_result`)
+
+Speech recognition result text.
+
+```json
+{"type": "asr_result", "code": 0, "data": "recognized text"}
+```
+
+**Device handling**: Display text, switch to `analyzing` animation.
+
+---
+
+### 3.2 Bot Reply (`bot_reply`)
+
+AI response text.
+
+```json
+{"type": "bot_reply", "code": 0, "data": "AI response content"}
+```
+
+**Device handling**: Optional text display, prepare for TTS audio.
+
+---
+
+### 3.3 Status (`status`)
+
+System status notification.
+
+```json
+{"type": "status", "code": 0, "data": "status description"}
+```
+
+Examples:
+- `[thinking] Processing...` — AI thinking
+- `Servo animation started: speech_nod`
+
+---
+
+### 3.4 Error (`error`)
+
+Error notification.
+
+```json
+{"type": "error", "code": 1, "data": "error description"}
+```
+
+**Device handling**: Display error state, switch to `sad` animation.
+
+---
+
+### 3.5 Servo Control (`servo`) — Updated v2.3
+
+Real-time servo angle command. **Now controls GPIO directly** (no UART).
+
+```json
+{"type": "servo", "code": 0, "data": {"id": "X", "angle": 90, "time": 500}}
+```
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| id | string | "X" or "Y" | Servo axis identifier |
+| angle | int | 0–180 | Target angle (degrees) |
+| time | int | 0–5000 | Move duration (ms), optional, default 0 |
+
+**Device handling**:
+```
+ws_router → on_servo_handler() → hal_servo_move_smooth(axis, angle, time)
+                                       ↓
+                               GPIO 19/20 LEDC PWM
+```
+
+**GPIO Mapping**:
+- GPIO 19 → Servo X-axis (left/right, 0–180°)
+- GPIO 20 → Servo Y-axis (up/down, 90–150° mechanical limit)
+
+---
+
+### 3.6 Display (`display`)
+
+Control screen text and animation.
+
+```json
+{"type": "display", "code": 0, "data": {"text": "Hello!", "emoji": "happy"}}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| text | string | Display text (optional) |
+| emoji | string | Animation name (optional) |
+
+**Available animations**: `happy`, `sad`, `surprised`, `angry`, `standby`, `idle`, `listening`, `analyzing`, `thinking`, `speaking`
+
+---
+
+### 3.7 TTS End (`tts_end`)
+
+TTS synthesis complete, all audio sent.
+
+```json
+{"type": "tts_end", "code": 0, "data": "ok"}
+```
+
+**Device handling**:
+- Wait for I2S buffer to drain (~500ms)
+- Stop audio playback
+- Switch to `happy` animation
+- Resume wake word detection
+
+---
+
+### 3.8 TTS Audio (Binary)
+
+TTS synthesized audio data.
+
+- **Format**: Raw PCM (no header)
+- **Sample rate**: 24000 Hz
+- **Bit depth**: 16-bit signed
+- **Channels**: Mono
+
+**Device handling**: Write directly to I2S speaker.
+
+---
+
+### 3.9 Camera Control (New v2.3)
+
+#### Start streaming:
+```json
+{"type": "camera_start", "fps": 5}
+```
+
+#### Stop streaming:
+```json
+{"type": "camera_stop"}
+```
+
+#### Single capture:
+```json
+{"type": "camera_capture"}
+```
+
+---
+
+### 3.10 OTA Notification (New v2.3)
+
+Firmware update trigger.
+
+```json
+{
+  "type": "fw_ota_notify",
+  "version": "2.1.0",
+  "url": "https://server/firmware/watcher-2.1.0.bin",
+  "sha256": "abc123..."
+}
+```
+
+**Device handling**:
+1. Download firmware via HTTP (`esp_https_ota`)
+2. Write to OTA partition
+3. Validate SHA256
+4. Set boot partition, reboot
+
+---
+
+### 3.11 Reboot (`reboot`)
+
+Remote reboot command.
+
+```json
+{"type": "reboot"}
+```
+
+---
+
+## 4. Device → Server Messages
+
+### 4.1 Voice Audio (Binary)
+
+PCM audio stream from microphone.
+
+- **Format**: Raw PCM (no header)
+- **Sample rate**: 16000 Hz
+- **Bit depth**: 16-bit signed
+- **Channels**: Mono
+- **Frame size**: 1920 bytes (60ms)
+
+---
+
+### 4.2 Audio End (`audio_end`)
+
+Recording complete marker.
+
+```json
+{"type": "audio_end"}
+```
+
+---
+
+### 4.3 Status Report (`status`)
+
+Device state report.
+
+```json
+{"type": "status", "state": "listening"}
+```
+
+**States**: `listening`, `recording`, `thinking`, `speaking`, `idle`, `error`
+
+---
+
+### 4.4 Device Info (`device_info`)
+
+Sent on WebSocket connect.
+
+```json
+{
+  "type": "device_info",
+  "fw_version": "2.0.0",
+  "hw_id": "Watcher-XXXX",
+  "ota_partition": "ota_0"
+}
+```
+
+---
+
+### 4.5 OTA Progress (`fw_ota_progress`)
+
+OTA download progress report.
+
+```json
+{"type": "fw_ota_progress", "percent": 45}
+```
+
+---
+
+### 4.6 OTA Complete (`fw_ota_complete`)
+
+OTA finished notification.
+
+```json
+{"type": "fw_ota_complete", "status": "ok"}
+```
+
+---
+
+### 4.7 Camera AI Result (`camera_ai_result`)
+
+Object detection result from Himax.
+
+```json
+{
+  "type": "camera_ai_result",
+  "boxes": [
+    {"class": "person", "confidence": 0.95, "x": 100, "y": 80, "w": 50, "h": 120}
+  ],
+  "timestamp": 1234567890
+}
+```
+
+---
+
+## 5. Binary Frame Formats
+
+### 5.1 Video Frame (WVID)
+
+```
+Offset  Size  Field
+0       4     Magic: "WVID"
+4       4     Timestamp (ms, uint32 big-endian)
+8       2     Width (pixels)
+10      2     Height (pixels)
+12      4     JPEG size (bytes)
+16      N     JPEG data
+```
+
+---
+
+## 6. Service Discovery
+
+UDP broadcast for server discovery.
+
+**Port**: 8767
+
+**Device broadcast**:
+```json
+{"type": "discovery", "device": "WatcheRobot", "firmware": "2.0.0"}
+```
+
+**Server response**:
+```json
+{"type": "discovery", "ip": "192.168.1.100", "port": 8766}
+```
+
+---
+
+## 7. Message Flow Examples
+
+### 7.1 Voice Conversation (Button Trigger)
+
+```
+Device                              Server
+  │                                   │
+  │  Button pressed → start recording │
+  │  ─── Binary PCM 16kHz ───────────►│
+  │  ─── {"type": "audio_end"} ──────►│
+  │                                   │
+  │  ◄── {"type": "asr_result"} ──────│
+  │  ◄── {"type": "bot_reply"} ───────│
+  │  ◄── Binary PCM 24kHz (TTS) ──────│
+  │  ◄── {"type": "tts_end"} ─────────│
+  │                                   │
+  │  Resume wake word detection       │
+  │                                   │
+```
+
+### 7.2 Wake Word Trigger
+
+```
+Device                              Server
+  │                                   │
+  │  Wake word "Hi 乐鑫" detected      │
+  │  ─── {"type": "status",           │
+  │       "state": "listening"} ─────►│
+  │                                   │
+  │  VAD detects speech → recording   │
+  │  ─── Binary PCM 16kHz ───────────►│
+  │  (VAD silence → auto stop)        │
+  │  ─── {"type": "audio_end"} ──────►│
+  │                                   │
+  │  (Same as button flow)            │
+  │                                   │
+```
+
+### 7.3 Servo Control Flow
+
+```
+Device                              Server
+  │                                   │
+  │  ◄── {"type": "servo",            │
+  │       "data": {"id":"X",          │
+  │       "angle": 90, "time": 500}} ─│
+  │                                   │
+  │  hal_servo_move_smooth(X,90,500)  │
+  │  → GPIO 19 LEDC PWM               │
+  │                                   │
+```
+
+---
+
+## 8. Animation Mapping
+
+| emoji | Animation | Use Case |
+|-------|-----------|----------|
+| `happy` | GREETING | Welcome, TTS complete |
+| `sad` | DETECTED | Error, regret |
+| `surprised` | DETECTING | Unexpected event |
+| `angry` | ANALYZING | Warning |
+| `standby` / `idle` | STANDBY | Default, wake word detection |
+| `listening` | LISTENING | Recording, wake word detected |
+| `analyzing` / `thinking` | ANALYZING | AI processing |
+| `speaking` | LISTENING (temp) | TTS playback |
+
+---
+
+## 9. Audio Parameters
+
+| Direction | Purpose | Sample Rate | Format | Bandwidth |
+|-----------|---------|-------------|--------|-----------|
+| Device → Server | Voice upload | 16kHz | 16-bit PCM mono | 256 kbps |
+| Server → Device | TTS playback | 24kHz | 16-bit PCM mono | 384 kbps |
+
+---
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 2.3 | 2026-03-11 | Servo GPIO direct control, camera streaming, OTA support |
+| 2.2 | 2026-03-11 | Architecture restructure (MCU removed) |
+| 2.1 | 2026-03-11 | Added display message, audio_end, wake word flow |
+| 2.0 | 2026-03-01 | Unified message format, removed AUD1 header, added asr_result/bot_reply/tts_end |
+| 1.1 | 2026-02-28 | Audio format changed from Opus to raw PCM |
+| 1.0 | 2026-02-28 | Initial version |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,280 @@
+# Development Roadmap
+
+> WatcheRobot Firmware development phases and priorities
+
+---
+
+## Current Version: 2.0.0 (Phase 1 Complete)
+
+Phase 1 delivered the four-layer component architecture migration from MVP-W prototype.
+
+---
+
+## Phase Overview
+
+| Phase | Description | Priority | Status |
+|-------|-------------|----------|--------|
+| **Phase 1** | Architecture Migration | P0 | ✅ Complete |
+| **Phase 2** | Servo Direct Drive | P0 | 🔲 Pending |
+| **Phase 3** | Animation 30fps | P0 | 🔲 Pending |
+| **Phase 4** | Dual OTA Partition | P1 | 🔲 Pending |
+| **Phase 5** | Firmware OTA | P1 | 🔲 Pending |
+| **Phase 6** | BLE Service | P1 | 🔲 Pending |
+| **Phase 7** | Camera Streaming | P1 | 🔲 Pending |
+| **Phase 8** | Animation OTA | P2 | 🔲 Pending |
+
+---
+
+## Phase 1: Architecture Migration ✅
+
+**Status**: Complete
+**Commit**: `cf1900f`
+
+### Deliverables
+- [x] Four-layer component structure (drivers/hal/protocols/services/utils)
+- [x] Code migration from MVP-W `main/` to components
+- [x] Remove `cJSON.c` → use ESP-IDF `json` component
+- [x] Remove `uart_bridge` → will be replaced by `hal_servo`
+- [x] Component `CMakeLists.txt` with proper `REQUIRES`/`PRIV_REQUIRES`
+- [x] `idf_component.yml` manifests
+- [x] Documentation structure
+
+---
+
+## Phase 2: Servo Direct Drive (P0)
+
+**Status**: Pending
+**Prerequisite**: Phase 1
+**Est. Effort**: 2-3 days
+
+### Goal
+Replace UART→MCU servo control with direct GPIO 19/20 LEDC PWM.
+
+### Component: `hal/hal_servo`
+
+```
+hal_servo/
+├── CMakeLists.txt
+├── idf_component.yml
+├── Kconfig
+├── README.md
+├── include/
+│   └── hal_servo.h
+├── src/
+│   └── hal_servo.c
+└── test_apps/
+    └── main/
+        └── test_hal_servo.c
+```
+
+### Key Features
+- LEDC Timer 0, 50Hz, 14-bit resolution
+- Channel 0 → GPIO 19 (X-axis)
+- Channel 1 → GPIO 20 (Y-axis)
+- Smooth move with FreeRTOS background task (10ms step)
+- Y-axis mechanical limit: 90°–150° (Kconfig)
+
+### API
+```c
+esp_err_t hal_servo_init(void);
+esp_err_t hal_servo_set_angle(servo_axis_t axis, int angle_deg);
+esp_err_t hal_servo_move_smooth(servo_axis_t axis, int angle_deg, int duration_ms);
+esp_err_t hal_servo_move_sync(int x_deg, int y_deg, int duration_ms);
+int hal_servo_get_angle(servo_axis_t axis);
+```
+
+### Migration Source
+`firmware/mcu/main/servo_control.c` → Logic移植, GPIO changed
+
+---
+
+## Phase 3: Animation 30fps (P0)
+
+**Status**: Pending
+**Prerequisite**: Phase 1
+**Est. Effort**: 3-4 days
+
+### Goal
+Achieve smooth 30fps animation playback with PNG→RGB565 PSRAM caching.
+
+### Component: `services/anim_service`
+
+### Key Changes
+- **anim_storage.c**: Load PNG, decode to RGB565, store in PSRAM
+- **anim_player.c**: Use `lv_animimg` widget, < 1ms frame switch
+- **anim_meta.c**: Parse `/spiffs/anim/anim_meta.json`
+
+### Memory Strategy
+- Single frame: 412 × 412 × 2 = 332KB (RGB565)
+- Lazy load: Only current animation type's frames in PSRAM
+- Max ~18 frames per animation type
+
+### Target Performance
+- FPS: 30 (was ~6.7fps)
+- Frame switch: < 1ms
+- Type switch: < 500ms (decode + load)
+
+---
+
+## Phase 4: Dual OTA Partition (P1)
+
+**Status**: Pending
+**Prerequisite**: Phase 1
+**Est. Effort**: 1 day
+
+### Goal
+Switch from `factory` to `ota_0`/`ota_1` partition layout.
+
+### Partition Table
+```csv
+# Name,    Type, SubType,  Offset,    Size
+nvs,       data, nvs,      0x9000,    0x6000
+phy_init,  data, phy,      0xF000,    0x1000
+otadata,   data, ota,      0x10000,   0x2000
+ota_0,     app,  ota_0,    0x20000,   0x500000
+ota_1,     app,  ota_1,    0x520000,  0x500000
+model,     data, spiffs,   0xA20000,  0x50000
+storage,   data, spiffs,   0xA70000,  0x580000
+```
+
+### Notes
+- First flash requires full erase
+- Manual `esp_ota_set_boot_partition()` for initial setup
+
+---
+
+## Phase 5: Firmware OTA (P1)
+
+**Status**: Pending
+**Prerequisite**: Phase 4
+**Est. Effort**: 2-3 days
+
+### Component: `services/ota_service`
+
+### Flow
+1. Server sends `fw_ota_notify` with URL + SHA256
+2. Device downloads via `esp_https_ota`
+3. Validate SHA256, set boot partition
+4. Reboot
+5. `ota_service_mark_valid()` on success (prevent rollback)
+
+### API
+```c
+esp_err_t ota_service_init(void);
+esp_err_t ota_service_start(const char *url, const char *expected_version);
+void ota_service_mark_valid(void);
+const char* ota_service_get_fw_version(void);
+```
+
+---
+
+## Phase 6: BLE Service (P1)
+
+**Status**: Pending
+**Prerequisite**: Phase 1
+**Est. Effort**: 3-4 days
+
+### Component: `protocols/ble_service`
+
+### Features
+1. **GATT Control Service** (UUID 0x1234)
+   - Servo control
+   - Display update
+   - Status notification
+
+2. **WiFi Provisioning**
+   - ESP-IDF `wifi_provisioning` over BLE
+
+### Config
+```kconfig
+config WATCHER_BLE_ENABLE
+    bool "Enable BLE service"
+    default n
+```
+
+### Coexistence
+- Enable `CONFIG_ESP32_WIFI_SW_COEXIST_ENABLE`
+- Limit BLE advertising during TTS playback
+
+---
+
+## Phase 7: Camera Streaming (P1)
+
+**Status**: Pending
+**Prerequisite**: Phase 1 + Hardware verification
+**Est. Effort**: 4-5 days
+
+### Components
+- `hal/hal_camera`: SSCMA client wrapper
+- `services/camera_service`: Streaming orchestration
+
+### Priority Rules
+- TTS playing → Stream paused
+- Voice recording → Stream throttled to 1fps
+- WebSocket disconnected → Stream stopped
+
+### Binary Frame Format (WVID)
+```
+Offset  Size  Field
+0       4     Magic: "WVID"
+4       4     Timestamp (ms)
+8       2     Width
+10      2     Height
+12      4     JPEG size
+16      N     JPEG data
+```
+
+---
+
+## Phase 8: Animation OTA (P2)
+
+**Status**: Pending
+**Prerequisite**: Phase 3
+**Est. Effort**: 2-3 days
+
+### Goal
+Hot-swap animation assets via WebSocket.
+
+### Flow
+1. Server sends `anim_ota_start` with metadata
+2. Device receives PNG frames via binary WebSocket
+3. Write to `/spiffs/anim/` SPIFFS
+4. Update `anim_meta.json`
+5. Reload animation
+
+---
+
+## Dependencies Graph
+
+```
+Phase 1 (Architecture)
+    │
+    ├──► Phase 2 (Servo)
+    │
+    ├──► Phase 3 (Animation)
+    │        │
+    │        └──► Phase 8 (Anim OTA)
+    │
+    ├──► Phase 4 (Partitions)
+    │        │
+    │        └──► Phase 5 (Firmware OTA)
+    │
+    ├──► Phase 6 (BLE)
+    │
+    └──► Phase 7 (Camera)
+```
+
+---
+
+## Milestone Releases
+
+| Version | Phases | Target |
+|---------|--------|--------|
+| 2.1.0 | Phase 2 + 3 | Core functionality |
+| 2.2.0 | Phase 4 + 5 | OTA ready |
+| 2.3.0 | Phase 6 + 7 | Full featured |
+| 3.0.0 | Phase 8 + Refinements | Production ready |
+
+---
+
+*Last updated: 2026-03-11*


### PR DESCRIPTION
## Summary

Migrate documentation from MVP-W prototype to the new component-based architecture repository.

### New Documents

| File | Description |
|------|-------------|
| `docs/protocol/websocket-protocol.md` | WebSocket protocol v2.3 (GPIO servo, camera, OTA) |
| `docs/protocol/voice-stream.md` | Audio streaming specification |
| `docs/development/known-issues.md` | Known issues (AFE ringbuffer) |
| `docs/development/testing.md` | Integration testing guide |
| `docs/roadmap.md` | Development phases (Phase 1-8) |

### Key Changes

- **Protocol version**: v2.1 → v2.3
- **Servo control**: UART→MCU replaced by GPIO 19/20 LEDC PWM direct drive
- **MCU architecture**: Removed
- **New message types**: `camera_start/stop`, `fw_ota_notify`, `reboot`

### Updated

- `README.md`: Reorganized documentation section with new links

## Test Plan

- [ ] Verify all documentation links work
- [ ] Review protocol changes for accuracy
- [ ] Confirm roadmap aligns with PRD v2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)