### PR TITLE
Make button restart available earlier

### DIFF
--- a/firmware/s3/components/hal/hal_button/src/hal_button.c
+++ b/firmware/s3/components/hal/hal_button/src/hal_button.c
@@ -55,15 +55,18 @@ bool hal_button_io_ready(void) {
 
     if (g_probe_cached) {
         if (g_probe_ready) {
+            ESP_LOGI(TAG, "IO expander button probe cached as ready");
             return true;
         }
         if (now_ms - g_last_probe_time_ms < BUTTON_IO_EXPANDER_PROBE_COOLDOWN_MS) {
+            ESP_LOGW(TAG,
+                     "IO expander button probe still cooling down (%lld ms remaining)",
+                     (long long)(BUTTON_IO_EXPANDER_PROBE_COOLDOWN_MS - (now_ms - g_last_probe_time_ms)));
             return false;
         }
     }
 
     esp_err_t ret = hal_button_read_level(&level);
-    (void)level;
     g_last_probe_time_ms = now_ms;
     g_probe_cached = true;
     g_probe_ready = (ret == ESP_OK);
@@ -73,6 +76,7 @@ bool hal_button_io_ready(void) {
         return false;
     }
 
+    ESP_LOGI(TAG, "IO expander button probe succeeded (level=%u)", (unsigned)level);
     return true;
 }
 

--- a/firmware/s3/components/hal/hal_display/src/hal_display.c
+++ b/firmware/s3/components/hal/hal_display/src/hal_display.c
@@ -792,19 +792,28 @@ int hal_display_ui_init(void) {
 }
 
 int hal_display_input_init(void) {
+    bool button_ready;
+
     if (inputs_initialized) {
+        ESP_LOGI(TAG, "Delayed display inputs already initialized (knob=%d touch=%d)",
+                 s_knob_indev != NULL ? 1 : 0,
+                 s_touch_indev != NULL ? 1 : 0);
         return 0;
     }
 
     if (hal_display_minimal_init() != 0) {
+        ESP_LOGW(TAG, "Delayed display inputs aborted because minimal display init is unavailable");
         return -1;
     }
 
     ESP_LOGI(TAG, "Initializing delayed display inputs...");
 
-    if (hal_button_io_ready()) {
+    button_ready = hal_button_io_ready();
+    ESP_LOGI(TAG, "Button IO ready probe result=%d", button_ready ? 1 : 0);
+
+    if (button_ready) {
         if (hal_display_init_knob_input() == NULL) {
-            ESP_LOGW(TAG, "Knob input initialization failed");
+            ESP_LOGW(TAG, "Knob input initialization failed after successful button probe");
         }
     } else {
         ESP_LOGW(TAG, "Skipping knob input initialization because IO expander button probe failed");
@@ -814,6 +823,10 @@ int hal_display_input_init(void) {
     }
 
     inputs_initialized = (s_knob_indev != NULL) || (s_touch_indev != NULL);
+    ESP_LOGI(TAG, "Delayed display inputs ready: knob=%d touch=%d any=%d",
+             s_knob_indev != NULL ? 1 : 0,
+             s_touch_indev != NULL ? 1 : 0,
+             inputs_initialized ? 1 : 0);
     return inputs_initialized ? 0 : -1;
 }
 

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -31,7 +31,7 @@
 #define TAG "MAIN"
 
 /* Physical restart: click count to trigger reboot */
-#define RESTART_CLICK_COUNT 5
+#define RESTART_CLICK_COUNT 3
 #define STARTUP_BEHAVIOR_POLL_MS 50
 #define STARTUP_BEHAVIOR_TIMEOUT_MS 10000
 #define BOOT_DISCOVERY_TIMEOUT_MS 5000
@@ -153,6 +153,27 @@ static void on_button_multi_click_restart(void) {
     behavior_state_set_with_text("error", "Rebooting...", 0);
     vTaskDelay(pdMS_TO_TICKS(500));
     esp_restart();
+}
+
+static void init_runtime_inputs_and_restart_path(void) {
+    int input_ret;
+    bool knob_ready;
+
+    input_ret = hal_display_input_init();
+    knob_ready = hal_display_has_knob_input();
+
+    ESP_LOGI(TAG, "Delayed input init result=%d knob_ready=%d", input_ret, knob_ready ? 1 : 0);
+
+    if (input_ret != 0) {
+        ESP_LOGW(TAG, "Delayed display input initialization failed; continuing with degraded input availability");
+    }
+
+    if (knob_ready) {
+        bsp_set_btn_multi_click_cb(RESTART_CLICK_COUNT, on_button_multi_click_restart);
+        ESP_LOGI(TAG, "Registered %d-click restart callback", RESTART_CLICK_COUNT);
+    } else {
+        ESP_LOGW(TAG, "Skipping %d-click restart callback because knob input is unavailable", RESTART_CLICK_COUNT);
+    }
 }
 
 static void run_camera_boot_diag(void) {
@@ -419,18 +440,8 @@ void app_main(void) {
     s_waiting_for_wifi_provision = false;
     log_heap_state("before_ui_init");
     hal_display_ui_init();
+    init_runtime_inputs_and_restart_path();
     if (cloud_ready) {
-        if (hal_display_input_init() != 0) {
-            ESP_LOGW(TAG, "Delayed display input initialization failed");
-        }
-
-        /* Register encoder callbacks only after delayed input devices are attached. */
-        if (hal_display_has_knob_input()) {
-            bsp_set_btn_multi_click_cb(RESTART_CLICK_COUNT, on_button_multi_click_restart);
-        } else {
-            ESP_LOGW(TAG, "Skipping %d-click restart callback because knob input is unavailable", RESTART_CLICK_COUNT);
-        }
-
         voice_recorder_init();
         if (voice_recorder_start() != 0) {
             ESP_LOGE(TAG, "Failed to start voice recorder (non-fatal)");


### PR DESCRIPTION
## Summary
- change physical restart trigger from 5 short presses to 3
- initialize runtime display inputs and register restart callback after boot UI setup regardless of cloud readiness
- add logging around button IO probe and delayed input init to make timing failures visible

## Validation
- idf.py build
- flashed to s3-c on COM28 and verified boot logs include delayed input init success and 3-click restart callback registration

## Notes
- left generated spiffs anim manifest changes out of this commit
