### PR TITLE
Refactor BLE-priority transport recovery

### DIFF
--- a/firmware/s3/components/protocols/ble_service/include/ble_service.h
+++ b/firmware/s3/components/protocols/ble_service/include/ble_service.h
@@ -14,9 +14,12 @@
 #include "esp_err.h"
 #include <stdbool.h>
 
+typedef void (*ble_service_connection_callback_t)(bool connected);
+
 esp_err_t ble_service_init(void);
 esp_err_t ble_service_start_advertising(void);
 esp_err_t ble_service_stop_advertising(void);
 bool ble_service_is_connected(void);
+void ble_service_register_connection_callback(ble_service_connection_callback_t cb);
 
 #endif /* BLE_SERVICE_H */

--- a/firmware/s3/components/protocols/ble_service/src/ble_service.c
+++ b/firmware/s3/components/protocols/ble_service/src/ble_service.c
@@ -77,6 +77,7 @@ static uint16_t s_conn_id = 0;
 static bool s_connected = false;
 static bool s_notify_enabled = false;
 static bool s_stack_ready = false;
+static ble_service_connection_callback_t s_connection_cb = NULL;
 
 typedef enum {
     BLE_PROTOCOL_MODE_LEGACY = 0,
@@ -133,6 +134,13 @@ static void ble_gatts_profile_event_handler(esp_gatts_cb_event_t event,
                                             esp_ble_gatts_cb_param_t *param);
 static void ble_send_text_notification(const char *text);
 static void ble_send_current_wifi_status_notification(void);
+
+static void ble_notify_connection_changed(bool connected)
+{
+    if (s_connection_cb != NULL) {
+        s_connection_cb(connected);
+    }
+}
 
 static void ble_set_response(char *response, size_t response_len, const char *text)
 {
@@ -440,7 +448,9 @@ static esp_err_t ble_parse_wifi_config(const char *payload, char *response, size
     }
 
     ESP_LOGI(TAG, "BLE WiFi provisioning request received for SSID: %s", ssid->valuestring);
-    int ret = wifi_provision(ssid->valuestring, password->valuestring);
+    int ret = s_connected
+                  ? wifi_store_credentials(ssid->valuestring, password->valuestring)
+                  : wifi_provision(ssid->valuestring, password->valuestring);
     cJSON_Delete(root);
 
     if (ret != 0) {
@@ -448,7 +458,7 @@ static esp_err_t ble_parse_wifi_config(const char *payload, char *response, size
         return ESP_FAIL;
     }
 
-    ble_set_response(response, response_len, "WIFI_CONNECTING\n");
+    ble_set_response(response, response_len, s_connected ? "WIFI_SAVED\n" : "WIFI_CONNECTING\n");
     return ESP_OK;
 }
 
@@ -1162,6 +1172,7 @@ static void ble_gatts_profile_event_handler(esp_gatts_cb_event_t event,
             s_notify_enabled = false;
             s_protocol_mode = BLE_PROTOCOL_MODE_LEGACY;
             ESP_LOGI(TAG, "BLE client connected, conn_id=%d", s_conn_id);
+            ble_notify_connection_changed(true);
             break;
 
         case ESP_GATTS_DISCONNECT_EVT:
@@ -1170,6 +1181,7 @@ static void ble_gatts_profile_event_handler(esp_gatts_cb_event_t event,
             s_protocol_mode = BLE_PROTOCOL_MODE_LEGACY;
             ESP_LOGI(TAG, "BLE client disconnected (reason=0x%x), restart adv",
                      param->disconnect.reason);
+            ble_notify_connection_changed(false);
             esp_ble_gap_start_advertising(&s_adv_params);
             break;
 
@@ -1341,6 +1353,11 @@ bool ble_service_is_connected(void)
     return s_connected;
 }
 
+void ble_service_register_connection_callback(ble_service_connection_callback_t cb)
+{
+    s_connection_cb = cb;
+}
+
 #else
 
 #include "esp_err.h"
@@ -1366,6 +1383,11 @@ esp_err_t ble_service_stop_advertising(void)
 bool ble_service_is_connected(void)
 {
     return false;
+}
+
+void ble_service_register_connection_callback(ble_service_connection_callback_t cb)
+{
+    (void)cb;
 }
 
 #endif

--- a/firmware/s3/components/protocols/ws_client/include/ws_client.h
+++ b/firmware/s3/components/protocols/ws_client/include/ws_client.h
@@ -79,6 +79,11 @@ int ws_client_start(void);
 void ws_client_stop(void);
 
 /**
+ * Destroy the current WebSocket client handle.
+ */
+void ws_client_deinit(void);
+
+/**
  * Send binary data via WebSocket
  * @param data Data buffer
  * @param len Data length
@@ -97,6 +102,11 @@ int ws_client_send_text(const char *text);
  * Check if WebSocket is connected
  */
 int ws_client_is_connected(void);
+
+/**
+ * Check if the WebSocket transport has been started.
+ */
+int ws_client_is_started(void);
 
 /**
  * Check if the WebSocket session is ready for business traffic.

--- a/firmware/s3/components/protocols/ws_client/src/ws_client.c
+++ b/firmware/s3/components/protocols/ws_client/src/ws_client.c
@@ -45,6 +45,7 @@
 #define WS_AUDIO_WORKER_WAIT_MS 20
 
 static esp_websocket_client_handle_t s_ws_client = NULL;
+static bool s_ws_started = false;
 static bool s_socket_connected = false;
 static bool s_hello_acknowledged = false;
 static bool s_tts_playing = false;
@@ -1049,6 +1050,7 @@ static void ws_event_handler(void *handler_args, esp_event_base_t base, int32_t 
     switch (event_id) {
     case WEBSOCKET_EVENT_CONNECTED:
         ESP_LOGI(TAG, "WebSocket connected");
+        s_ws_started = true;
         s_socket_connected = true;
         s_hello_acknowledged = false;
         s_waiting_for_response = false;
@@ -1062,6 +1064,7 @@ static void ws_event_handler(void *handler_args, esp_event_base_t base, int32_t 
 
     case WEBSOCKET_EVENT_DISCONNECTED:
         ESP_LOGW(TAG, "WebSocket disconnected");
+        s_ws_started = false;
         if (camera_service_is_streaming()) {
             ESP_LOGW(TAG, "stopping camera stream on WebSocket disconnect");
             camera_service_stop_stream();
@@ -1174,6 +1177,11 @@ int ws_client_start(void) {
         return -1;
     }
 
+    if (s_ws_started) {
+        ESP_LOGI(TAG, "WebSocket client already started");
+        return 0;
+    }
+
     ESP_LOGI(TAG, "Starting WebSocket client (URL: %s)", s_ws_server_url);
     ret = esp_websocket_client_start(s_ws_client);
     if (ret != ESP_OK) {
@@ -1181,11 +1189,18 @@ int ws_client_start(void) {
         return -1;
     }
 
+    s_ws_started = true;
     ESP_LOGI(TAG, "WebSocket start requested");
     return 0;
 }
 
 void ws_client_stop(void) {
+    if (s_ws_client == NULL) {
+        ws_reset_session_state();
+        s_ws_started = false;
+        return;
+    }
+
     if (camera_service_is_streaming()) {
         camera_service_stop_stream();
     }
@@ -1204,13 +1219,27 @@ void ws_client_stop(void) {
         }
     }
 
-    if (s_ws_client != NULL) {
-        esp_websocket_client_stop(s_ws_client);
-        esp_websocket_client_destroy(s_ws_client);
-        s_ws_client = NULL;
+    if (s_ws_started) {
+        esp_err_t err = esp_websocket_client_stop(s_ws_client);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "WebSocket stop returned: %s", esp_err_to_name(err));
+        }
     }
 
+    s_ws_started = false;
     ws_reset_session_state();
+}
+
+void ws_client_deinit(void) {
+    if (s_ws_client == NULL) {
+        s_ws_started = false;
+        ws_reset_session_state();
+        return;
+    }
+
+    ws_client_stop();
+    esp_websocket_client_destroy(s_ws_client);
+    s_ws_client = NULL;
 }
 
 int ws_client_send_binary(const uint8_t *data, int len) {
@@ -1227,6 +1256,10 @@ int ws_client_send_text(const char *text) {
 
 int ws_client_is_connected(void) {
     return s_socket_connected ? 1 : 0;
+}
+
+int ws_client_is_started(void) {
+    return s_ws_started ? 1 : 0;
 }
 
 int ws_client_is_session_ready(void) {

--- a/firmware/s3/components/services/anim_service/src/anim_player.c
+++ b/firmware/s3/components/services/anim_service/src/anim_player.c
@@ -303,15 +303,6 @@ static void note_frame_switch(emoji_anim_type_t type) {
         return;
     }
 
-    double actual_fps = ((double)g_fps_diag.frame_switches * 1000000.0) / (double)elapsed_us;
-    ESP_LOGI(TAG,
-             "Playback FPS type=%s actual=%.2f target=%d frames=%lu window_ms=%lu",
-             anim_type_name_or_none(type),
-             actual_fps,
-             emoji_anim_get_fps(),
-             (unsigned long)g_fps_diag.frame_switches,
-             (unsigned long)(elapsed_us / 1000ULL));
-
     g_fps_diag.window_start_us = now_us;
     g_fps_diag.frame_switches = 0;
 }

--- a/firmware/s3/components/utils/wifi_manager/include/wifi_manager.h
+++ b/firmware/s3/components/utils/wifi_manager/include/wifi_manager.h
@@ -30,6 +30,12 @@ int wifi_connect(void);
 int wifi_connect_async(void);
 
 /**
+ * Resume background WiFi connectivity after BLE releases transport ownership.
+ * @return 0 when the resume request is accepted, -1 on error
+ */
+int wifi_resume_background(void);
+
+/**
  * Wait until WiFi gets an IP address.
  * @param timeout_ms Timeout in milliseconds. Pass a negative value to wait forever.
  * @return 0 on success, -1 on timeout/error
@@ -89,8 +95,23 @@ void wifi_register_status_callback(wifi_status_callback_t cb);
 int wifi_is_connected(void);
 
 /**
+ * Return 1 if the STA driver has emitted START, otherwise 0.
+ */
+int wifi_sta_is_started(void);
+
+/**
+ * Return 1 if a background connect has been requested, otherwise 0.
+ */
+int wifi_is_connect_requested(void);
+
+/**
  * Disconnect WiFi
  */
 void wifi_disconnect(void);
+
+/**
+ * Suspend WiFi reconnect activity while BLE owns the transport.
+ */
+void wifi_suspend_for_ble(void);
 
 #endif /* WIFI_CLIENT_H */

--- a/firmware/s3/components/utils/wifi_manager/src/wifi_manager.c
+++ b/firmware/s3/components/utils/wifi_manager/src/wifi_manager.c
@@ -128,20 +128,6 @@ static void wifi_apply_sta_defaults(wifi_sta_config_t *sta_cfg,
     sta_cfg->failure_retry_cnt = 3;
 }
 
-static void wifi_log_sta_security_profile(const wifi_sta_config_t *sta_cfg,
-                                          const char *source)
-{
-    ESP_LOGI(TAG,
-             "STA security profile (%s): auth_threshold=%d pmf_capable=%d pmf_required=%d sae_pwe=%d sae_pk=%d retry=%u",
-             source,
-             sta_cfg->threshold.authmode,
-             sta_cfg->pmf_cfg.capable ? 1 : 0,
-             sta_cfg->pmf_cfg.required ? 1 : 0,
-             sta_cfg->sae_pwe_h2e,
-             sta_cfg->sae_pk_mode,
-             (unsigned)sta_cfg->failure_retry_cnt);
-}
-
 static void wifi_notify_status(void)
 {
     for (size_t i = 0; i < WIFI_STATUS_CALLBACK_MAX; ++i) {
@@ -194,7 +180,6 @@ static int wifi_normalize_saved_sta_config(const char *source)
         return -1;
     }
 
-    wifi_log_sta_security_profile(&normalized_cfg.sta, source);
     return 0;
 }
 
@@ -438,8 +423,6 @@ int wifi_provision(const char *ssid, const char *password)
 
     wifi_config_t wifi_cfg = {0};
     wifi_apply_sta_defaults(&wifi_cfg.sta, ssid, ssid_len, password, pass_len);
-    wifi_log_sta_security_profile(&wifi_cfg.sta, "wifi_provision");
-
     if (wifi_start_if_needed() != 0) {
         return -1;
     }
@@ -487,8 +470,6 @@ int wifi_store_credentials(const char *ssid, const char *password)
 
     wifi_config_t wifi_cfg = {0};
     wifi_apply_sta_defaults(&wifi_cfg.sta, ssid, ssid_len, password, pass_len);
-    wifi_log_sta_security_profile(&wifi_cfg.sta, "wifi_store_credentials");
-
     if (wifi_start_if_needed() != 0) {
         return -1;
     }

--- a/firmware/s3/components/utils/wifi_manager/src/wifi_manager.c
+++ b/firmware/s3/components/utils/wifi_manager/src/wifi_manager.c
@@ -22,6 +22,7 @@ static EventGroupHandle_t wifi_event_group;
 static wifi_status_callback_t s_status_cbs[WIFI_STATUS_CALLBACK_MAX];
 static bool s_initialized = false;
 static bool s_wifi_started = false;
+static bool s_wifi_start_requested = false;
 static bool s_connect_requested = false;
 static bool s_connection_in_progress = false;
 static bool s_credentials_present = false;
@@ -29,6 +30,117 @@ static bool is_connected = false;
 static wifi_status_t s_status = WIFI_STATUS_UNCONFIGURED;
 static char s_saved_ssid[33] = {0};
 static char s_ip_addr[16] = {0};
+
+static const char *wifi_disconnect_reason_name(uint8_t reason)
+{
+    switch (reason) {
+    case WIFI_REASON_UNSPECIFIED:
+        return "UNSPECIFIED";
+    case WIFI_REASON_AUTH_EXPIRE:
+        return "AUTH_EXPIRE";
+    case WIFI_REASON_AUTH_LEAVE:
+        return "AUTH_LEAVE";
+    case WIFI_REASON_ASSOC_EXPIRE:
+        return "ASSOC_EXPIRE";
+    case WIFI_REASON_ASSOC_TOOMANY:
+        return "ASSOC_TOOMANY";
+    case WIFI_REASON_NOT_AUTHED:
+        return "NOT_AUTHED";
+    case WIFI_REASON_NOT_ASSOCED:
+        return "NOT_ASSOCED";
+    case WIFI_REASON_ASSOC_LEAVE:
+        return "ASSOC_LEAVE";
+    case WIFI_REASON_ASSOC_NOT_AUTHED:
+        return "ASSOC_NOT_AUTHED";
+    case WIFI_REASON_DISASSOC_PWRCAP_BAD:
+        return "DISASSOC_PWRCAP_BAD";
+    case WIFI_REASON_DISASSOC_SUPCHAN_BAD:
+        return "DISASSOC_SUPCHAN_BAD";
+    case WIFI_REASON_IE_INVALID:
+        return "IE_INVALID";
+    case WIFI_REASON_MIC_FAILURE:
+        return "MIC_FAILURE";
+    case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+        return "4WAY_HANDSHAKE_TIMEOUT";
+    case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
+        return "GROUP_KEY_UPDATE_TIMEOUT";
+    case WIFI_REASON_IE_IN_4WAY_DIFFERS:
+        return "IE_IN_4WAY_DIFFERS";
+    case WIFI_REASON_GROUP_CIPHER_INVALID:
+        return "GROUP_CIPHER_INVALID";
+    case WIFI_REASON_PAIRWISE_CIPHER_INVALID:
+        return "PAIRWISE_CIPHER_INVALID";
+    case WIFI_REASON_AKMP_INVALID:
+        return "AKMP_INVALID";
+    case WIFI_REASON_UNSUPP_RSN_IE_VERSION:
+        return "UNSUPP_RSN_IE_VERSION";
+    case WIFI_REASON_INVALID_RSN_IE_CAP:
+        return "INVALID_RSN_IE_CAP";
+    case WIFI_REASON_802_1X_AUTH_FAILED:
+        return "802_1X_AUTH_FAILED";
+    case WIFI_REASON_CIPHER_SUITE_REJECTED:
+        return "CIPHER_SUITE_REJECTED";
+    case WIFI_REASON_BEACON_TIMEOUT:
+        return "BEACON_TIMEOUT";
+    case WIFI_REASON_NO_AP_FOUND:
+        return "NO_AP_FOUND";
+    case WIFI_REASON_AUTH_FAIL:
+        return "AUTH_FAIL";
+    case WIFI_REASON_ASSOC_FAIL:
+        return "ASSOC_FAIL";
+    case WIFI_REASON_HANDSHAKE_TIMEOUT:
+        return "HANDSHAKE_TIMEOUT";
+    case WIFI_REASON_CONNECTION_FAIL:
+        return "CONNECTION_FAIL";
+    case WIFI_REASON_AP_TSF_RESET:
+        return "AP_TSF_RESET";
+    case WIFI_REASON_ROAMING:
+        return "ROAMING";
+    case WIFI_REASON_ASSOC_COMEBACK_TIME_TOO_LONG:
+        return "ASSOC_COMEBACK_TIME_TOO_LONG";
+    case WIFI_REASON_SA_QUERY_TIMEOUT:
+        return "SA_QUERY_TIMEOUT";
+    case WIFI_REASON_NO_AP_FOUND_W_COMPATIBLE_SECURITY:
+        return "NO_AP_FOUND_W_COMPATIBLE_SECURITY";
+    case WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD:
+        return "NO_AP_FOUND_IN_AUTHMODE_THRESHOLD";
+    case WIFI_REASON_NO_AP_FOUND_IN_RSSI_THRESHOLD:
+        return "NO_AP_FOUND_IN_RSSI_THRESHOLD";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+static void wifi_apply_sta_defaults(wifi_sta_config_t *sta_cfg,
+                                    const char *ssid, size_t ssid_len,
+                                    const char *password, size_t pass_len)
+{
+    memset(sta_cfg, 0, sizeof(*sta_cfg));
+    memcpy(sta_cfg->ssid, ssid, ssid_len);
+    memcpy(sta_cfg->password, password, pass_len);
+    sta_cfg->scan_method = WIFI_ALL_CHANNEL_SCAN;
+    sta_cfg->sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+    sta_cfg->threshold.authmode = WIFI_AUTH_WPA_PSK;
+    sta_cfg->pmf_cfg.capable = true;
+    sta_cfg->pmf_cfg.required = false;
+    sta_cfg->sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
+    sta_cfg->sae_pk_mode = WPA3_SAE_PK_MODE_AUTOMATIC;
+    sta_cfg->failure_retry_cnt = 3;
+}
+
+static void wifi_log_sta_security_profile(const wifi_sta_config_t *sta_cfg,
+                                          const char *source)
+{
+    ESP_LOGI(TAG,
+             "STA security profile (%s): auth_threshold=%d pmf_capable=%d pmf_required=%d sae_pwe=%d sae_pk=%d retry=%u",
+             source,
+             sta_cfg->threshold.authmode,
+             sta_cfg->pmf_cfg.capable ? 1 : 0,
+             sta_cfg->pmf_cfg.required ? 1 : 0,
+             sta_cfg->sae_pwe_h2e,
+             sta_cfg->sae_pk_mode,
+             (unsigned)sta_cfg->failure_retry_cnt);
+}
 
 static void wifi_notify_status(void)
 {
@@ -60,18 +172,46 @@ static void wifi_refresh_saved_config(void)
     }
 }
 
-static int wifi_start_if_needed(void)
+static int wifi_normalize_saved_sta_config(const char *source)
 {
-    if (s_wifi_started) {
-        return 0;
-    }
+    wifi_config_t current_cfg = {0};
+    wifi_config_t normalized_cfg = {0};
+    size_t ssid_len;
+    size_t pass_len;
 
-    if (esp_wifi_start() != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to start WiFi");
+    if (esp_wifi_get_config(WIFI_IF_STA, &current_cfg) != ESP_OK || current_cfg.sta.ssid[0] == '\0') {
         return -1;
     }
 
-    s_wifi_started = true;
+    ssid_len = strnlen((const char *)current_cfg.sta.ssid, sizeof(current_cfg.sta.ssid));
+    pass_len = strnlen((const char *)current_cfg.sta.password, sizeof(current_cfg.sta.password));
+    wifi_apply_sta_defaults(&normalized_cfg.sta,
+                            (const char *)current_cfg.sta.ssid, ssid_len,
+                            (const char *)current_cfg.sta.password, pass_len);
+
+    if (esp_wifi_set_config(WIFI_IF_STA, &normalized_cfg) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to normalize saved STA config (%s)", source);
+        return -1;
+    }
+
+    wifi_log_sta_security_profile(&normalized_cfg.sta, source);
+    return 0;
+}
+
+static int wifi_start_if_needed(void)
+{
+    if (s_wifi_started || s_wifi_start_requested) {
+        return 0;
+    }
+
+    esp_err_t err = esp_wifi_start();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start WiFi: %s", esp_err_to_name(err));
+        return -1;
+    }
+
+    s_wifi_start_requested = true;
+    ESP_LOGI(TAG, "WiFi start requested");
     return 0;
 }
 
@@ -88,6 +228,11 @@ static int wifi_request_connect(const char *source)
 
     if (s_connection_in_progress) {
         ESP_LOGI(TAG, "WiFi connect already in progress (%s)", source);
+        return 0;
+    }
+
+    if (!s_wifi_started) {
+        ESP_LOGI(TAG, "WiFi connect deferred until STA start (%s)", source);
         return 0;
     }
 
@@ -108,9 +253,23 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
     (void)arg;
 
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        s_wifi_started = true;
+        s_wifi_start_requested = false;
+        ESP_LOGI(TAG, "WiFi STA started");
         if (s_connect_requested && s_credentials_present) {
-            wifi_request_connect("sta_start");
+            if (wifi_request_connect("sta_start") == 0) {
+                wifi_set_status(WIFI_STATUS_CONNECTING);
+            }
         }
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_STOP) {
+        ESP_LOGI(TAG, "WiFi STA stopped");
+        s_wifi_started = false;
+        s_wifi_start_requested = false;
+        s_connection_in_progress = false;
+        is_connected = false;
+        s_ip_addr[0] = '\0';
+        xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
+        wifi_set_status(s_credentials_present ? WIFI_STATUS_DISCONNECTED : WIFI_STATUS_UNCONFIGURED);
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
         wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
         is_connected = false;
@@ -119,7 +278,13 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
         xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
 
         if (s_credentials_present) {
-            ESP_LOGW(TAG, "Disconnected from AP (reason=%d), retrying...", event ? event->reason : -1);
+            uint8_t reason = event ? event->reason : 0;
+            ESP_LOGW(TAG,
+                     "Disconnected from AP (reason=%u:%s, connect_requested=%d, sta_started=%d), retrying...",
+                     (unsigned)reason,
+                     wifi_disconnect_reason_name(reason),
+                     s_connect_requested ? 1 : 0,
+                     s_wifi_started ? 1 : 0);
             wifi_set_status(WIFI_STATUS_DISCONNECTED);
             if (s_connect_requested) {
                 if (wifi_request_connect("sta_disconnected") == 0) {
@@ -168,6 +333,7 @@ int wifi_init(void)
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
     ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_FLASH));
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
 
     ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
                                                         &wifi_event_handler, NULL, NULL));
@@ -183,45 +349,10 @@ int wifi_init(void)
     return 0;
 }
 
-int wifi_connect(void)
+int wifi_resume_background(void)
 {
     if (!s_initialized) {
         ESP_LOGE(TAG, "WiFi not initialized");
-        return -1;
-    }
-
-    if (wifi_start_if_needed() != 0) {
-        return -1;
-    }
-
-    wifi_refresh_saved_config();
-    xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
-
-    if (!s_credentials_present) {
-        ESP_LOGW(TAG, "No stored WiFi credentials; waiting for BLE provisioning");
-        wifi_set_status(WIFI_STATUS_UNCONFIGURED);
-        return -1;
-    }
-
-    s_connect_requested = true;
-    wifi_set_status(WIFI_STATUS_CONNECTING);
-    ESP_LOGI(TAG, "Connecting to stored WiFi SSID: %s", s_saved_ssid);
-    if (wifi_request_connect("wifi_connect") != 0) {
-        wifi_set_status(WIFI_STATUS_DISCONNECTED);
-        return -1;
-    }
-
-    return wifi_wait_for_connection(WIFI_WAIT_TIMEOUT_MS);
-}
-
-int wifi_connect_async(void)
-{
-    if (!s_initialized) {
-        ESP_LOGE(TAG, "WiFi not initialized");
-        return -1;
-    }
-
-    if (wifi_start_if_needed() != 0) {
         return -1;
     }
 
@@ -230,19 +361,47 @@ int wifi_connect_async(void)
 
     if (!s_credentials_present) {
         ESP_LOGW(TAG, "No stored WiFi credentials; BLE can continue without cloud");
+        s_connect_requested = false;
+        s_connection_in_progress = false;
         wifi_set_status(WIFI_STATUS_UNCONFIGURED);
         return -1;
     }
 
+    wifi_normalize_saved_sta_config("wifi_resume_background");
     s_connect_requested = true;
     wifi_set_status(WIFI_STATUS_CONNECTING);
-    ESP_LOGI(TAG, "Starting background WiFi connect to SSID: %s", s_saved_ssid);
-    if (wifi_request_connect("wifi_connect_async") != 0) {
+    ESP_LOGI(TAG, "Resuming background WiFi connect to SSID: %s", s_saved_ssid);
+
+    if (wifi_start_if_needed() != 0) {
+        wifi_set_status(WIFI_STATUS_DISCONNECTED);
+        return -1;
+    }
+
+    if (wifi_request_connect("wifi_resume_background") != 0) {
         wifi_set_status(WIFI_STATUS_DISCONNECTED);
         return -1;
     }
 
     return 0;
+}
+
+int wifi_connect(void)
+{
+    if (!s_initialized) {
+        ESP_LOGE(TAG, "WiFi not initialized");
+        return -1;
+    }
+
+    if (wifi_resume_background() != 0) {
+        return -1;
+    }
+
+    return wifi_wait_for_connection(WIFI_WAIT_TIMEOUT_MS);
+}
+
+int wifi_connect_async(void)
+{
+    return wifi_resume_background();
 }
 
 int wifi_wait_for_connection(int timeout_ms)
@@ -278,14 +437,8 @@ int wifi_provision(const char *ssid, const char *password)
     }
 
     wifi_config_t wifi_cfg = {0};
-    memcpy(wifi_cfg.sta.ssid, ssid, ssid_len);
-    memcpy(wifi_cfg.sta.password, password, pass_len);
-    wifi_cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-    wifi_cfg.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
-    wifi_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
-    wifi_cfg.sta.pmf_cfg.capable = true;
-    wifi_cfg.sta.pmf_cfg.required = false;
-    wifi_cfg.sta.failure_retry_cnt = 3;
+    wifi_apply_sta_defaults(&wifi_cfg.sta, ssid, ssid_len, password, pass_len);
+    wifi_log_sta_security_profile(&wifi_cfg.sta, "wifi_provision");
 
     if (wifi_start_if_needed() != 0) {
         return -1;
@@ -333,14 +486,8 @@ int wifi_store_credentials(const char *ssid, const char *password)
     }
 
     wifi_config_t wifi_cfg = {0};
-    memcpy(wifi_cfg.sta.ssid, ssid, ssid_len);
-    memcpy(wifi_cfg.sta.password, password, pass_len);
-    wifi_cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-    wifi_cfg.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
-    wifi_cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
-    wifi_cfg.sta.pmf_cfg.capable = true;
-    wifi_cfg.sta.pmf_cfg.required = false;
-    wifi_cfg.sta.failure_retry_cnt = 3;
+    wifi_apply_sta_defaults(&wifi_cfg.sta, ssid, ssid_len, password, pass_len);
+    wifi_log_sta_security_profile(&wifi_cfg.sta, "wifi_store_credentials");
 
     if (wifi_start_if_needed() != 0) {
         return -1;
@@ -451,12 +598,46 @@ int wifi_is_connected(void)
     return is_connected ? 1 : 0;
 }
 
+int wifi_sta_is_started(void)
+{
+    return s_wifi_started ? 1 : 0;
+}
+
+int wifi_is_connect_requested(void)
+{
+    return s_connect_requested ? 1 : 0;
+}
+
 void wifi_disconnect(void)
 {
     esp_wifi_disconnect();
     s_connect_requested = false;
+    s_connection_in_progress = false;
     is_connected = false;
     s_ip_addr[0] = '\0';
     xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
+    wifi_set_status(s_credentials_present ? WIFI_STATUS_DISCONNECTED : WIFI_STATUS_UNCONFIGURED);
+}
+
+void wifi_suspend_for_ble(void)
+{
+    esp_err_t err;
+
+    if (!s_initialized) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Suspending WiFi background activity for BLE");
+    s_connect_requested = false;
+    s_connection_in_progress = false;
+    is_connected = false;
+    s_ip_addr[0] = '\0';
+    xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
+
+    err = esp_wifi_disconnect();
+    if (err != ESP_OK && err != ESP_ERR_WIFI_NOT_STARTED && err != ESP_ERR_WIFI_CONN) {
+        ESP_LOGW(TAG, "esp_wifi_disconnect during BLE suspend returned: %s", esp_err_to_name(err));
+    }
+
     wifi_set_status(s_credentials_present ? WIFI_STATUS_DISCONNECTED : WIFI_STATUS_UNCONFIGURED);
 }

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -3,7 +3,9 @@
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_task_wdt.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
 #include "freertos/task.h"
 
 #include "anim_storage.h"
@@ -34,7 +36,9 @@
 #define RESTART_CLICK_COUNT 5
 #define STARTUP_BEHAVIOR_POLL_MS 50
 #define STARTUP_BEHAVIOR_TIMEOUT_MS 10000
-#define BOOT_DISCOVERY_TIMEOUT_MS 5000
+#define CLOUD_DISCOVERY_TIMEOUT_MS 5000
+#define CLOUD_RETRY_DELAY_MS 2000
+#define CLOUD_PROTOCOL_RETRY_DELAY_MS 5000
 #define CAMERA_DIAG_MIN_INTERNAL_FREE_BYTES (48U * 1024U)
 #define CAMERA_DIAG_MIN_INTERNAL_LARGEST_BYTES (16U * 1024U)
 #ifdef CONFIG_WATCHER_ANIM_FPS
@@ -43,11 +47,16 @@
 #define BOOT_ANIM_INTERVAL_MS 100U
 #endif
 
-static bool s_waiting_for_wifi_provision = false;
-static bool s_ble_only_mode = false;
-static bool s_wifi_paused_for_ble = false;
-static bool s_ws_paused_for_ble = false;
-static bool s_cloud_session_configured = false;
+typedef enum {
+    TRANSPORT_BLE_ACTIVE = 0,
+    TRANSPORT_BLE_IDLE_NO_CREDENTIALS,
+    TRANSPORT_BLE_IDLE_WIFI_STARTING,
+    TRANSPORT_BLE_IDLE_WIFI_CONNECTING,
+    TRANSPORT_BLE_IDLE_DISCOVERING,
+    TRANSPORT_BLE_IDLE_WS_CONNECTING,
+    TRANSPORT_BLE_IDLE_CLOUD_READY,
+    TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED,
+} transport_state_t;
 
 typedef enum {
     IDLE_HINT_READY = 0,
@@ -55,42 +64,97 @@ typedef enum {
     IDLE_HINT_BLE_NO_WIFI,
 } idle_hint_mode_t;
 
+typedef struct {
+    uint32_t generation;
+    int status;
+    server_info_t info;
+} discovery_result_t;
+
+static bool s_waiting_for_wifi_provision = false;
+static bool s_boot_completed = false;
+static bool s_cloud_runtime_started = false;
+static bool s_ws_router_ready = false;
+static bool s_ws_stack_ready = false;
+static bool s_discovery_initialized = false;
+static bool s_last_ble_connected = false;
+static transport_state_t s_transport_state = TRANSPORT_BLE_IDLE_NO_CREDENTIALS;
+static volatile bool s_discovery_inflight = false;
+static uint32_t s_discovery_generation = 0;
+static int64_t s_next_cloud_attempt_us = 0;
+static QueueHandle_t s_discovery_result_queue = NULL;
+
+static const char *transport_state_to_string(transport_state_t state) {
+    switch (state) {
+    case TRANSPORT_BLE_ACTIVE:
+        return "BLE_ACTIVE";
+    case TRANSPORT_BLE_IDLE_NO_CREDENTIALS:
+        return "BLE_IDLE_NO_CREDENTIALS";
+    case TRANSPORT_BLE_IDLE_WIFI_STARTING:
+        return "BLE_IDLE_WIFI_STARTING";
+    case TRANSPORT_BLE_IDLE_WIFI_CONNECTING:
+        return "BLE_IDLE_WIFI_CONNECTING";
+    case TRANSPORT_BLE_IDLE_DISCOVERING:
+        return "BLE_IDLE_DISCOVERING";
+    case TRANSPORT_BLE_IDLE_WS_CONNECTING:
+        return "BLE_IDLE_WS_CONNECTING";
+    case TRANSPORT_BLE_IDLE_CLOUD_READY:
+        return "BLE_IDLE_CLOUD_READY";
+    case TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED:
+    default:
+        return "BLE_IDLE_CLOUD_SUSPENDED";
+    }
+}
+
+static void transport_set_state(transport_state_t state, const char *reason) {
+    if (state == s_transport_state) {
+        return;
+    }
+
+    ESP_LOGI(TAG,
+             "Transport state: %s -> %s (%s)",
+             transport_state_to_string(s_transport_state),
+             transport_state_to_string(state),
+             reason ? reason : "no reason");
+    s_transport_state = state;
+}
+
+static void transport_schedule_retry(uint32_t delay_ms) {
+    s_next_cloud_attempt_us = esp_timer_get_time() + ((int64_t)delay_ms * 1000LL);
+}
+
+static bool transport_retry_due(void) {
+    return s_next_cloud_attempt_us == 0 || esp_timer_get_time() >= s_next_cloud_attempt_us;
+}
+
+#if CONFIG_WATCHER_CAMERA_BOOT_DIAG
 static bool has_internal_heap_headroom(size_t min_free_bytes, size_t min_largest_block_bytes) {
     size_t free_internal = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
     size_t largest_internal = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 
     return free_internal >= min_free_bytes && largest_internal >= min_largest_block_bytes;
 }
+#endif
 
 static void on_wifi_status_changed(wifi_status_t status, const char *ssid, const char *ip_addr) {
     switch (status) {
     case WIFI_STATUS_CONNECTED:
         ESP_LOGI(TAG, "WiFi connected: ssid=%s ip=%s", ssid ? ssid : "<unknown>",
                  ip_addr ? ip_addr : "<no-ip>");
-        if (s_wifi_paused_for_ble) {
-            break;
-        }
-        if (s_waiting_for_wifi_provision) {
+        if (!s_boot_completed && s_waiting_for_wifi_provision) {
             boot_anim_set_text("WiFi Connected");
         }
         break;
 
     case WIFI_STATUS_CONNECTING:
         ESP_LOGI(TAG, "WiFi connecting: ssid=%s", ssid ? ssid : "<unknown>");
-        if (s_wifi_paused_for_ble) {
-            break;
-        }
-        if (s_waiting_for_wifi_provision) {
+        if (!s_boot_completed && s_waiting_for_wifi_provision) {
             boot_anim_set_text("Connecting WiFi...");
         }
         break;
 
     case WIFI_STATUS_DISCONNECTED:
         ESP_LOGW(TAG, "WiFi connect failed or disconnected: ssid=%s", ssid ? ssid : "<unknown>");
-        if (s_wifi_paused_for_ble) {
-            break;
-        }
-        if (s_waiting_for_wifi_provision) {
+        if (!s_boot_completed && s_waiting_for_wifi_provision) {
             boot_anim_set_text("WiFi Failed, Retry");
         }
         break;
@@ -98,55 +162,12 @@ static void on_wifi_status_changed(wifi_status_t status, const char *ssid, const
     case WIFI_STATUS_UNCONFIGURED:
     default:
         ESP_LOGI(TAG, "WiFi unconfigured");
-        if (s_wifi_paused_for_ble) {
-            break;
-        }
-        if (s_waiting_for_wifi_provision) {
+        if (!s_boot_completed && s_waiting_for_wifi_provision) {
             boot_anim_set_text("Open APP Set WiFi");
         }
         break;
     }
 }
-
-static void handle_ble_transport_gate(bool ble_connected) {
-    static bool last_ble_connected = false;
-
-    if (ble_connected == last_ble_connected) {
-        if (!ble_connected &&
-            s_ws_paused_for_ble &&
-            s_cloud_session_configured &&
-            wifi_is_connected() == 1 &&
-            !ws_client_is_connected()) {
-            ESP_LOGI(TAG, "BLE released, resuming WebSocket session");
-            ws_client_start();
-            s_ws_paused_for_ble = false;
-        }
-        return;
-    }
-
-    last_ble_connected = ble_connected;
-
-    if (ble_connected) {
-        ESP_LOGI(TAG, "BLE connected, pausing WiFi/WS background activity");
-        s_wifi_paused_for_ble = true;
-        if (ws_client_is_connected() || ws_client_is_session_ready()) {
-            ws_client_stop();
-            s_ws_paused_for_ble = s_cloud_session_configured;
-        }
-        wifi_disconnect();
-        return;
-    }
-
-    ESP_LOGI(TAG, "BLE disconnected, resuming WiFi/WS background activity");
-    s_wifi_paused_for_ble = false;
-    if (wifi_has_credentials() == 1) {
-        wifi_connect_async();
-    }
-}
-
-/* ------------------------------------------------------------------ */
-/* Button Callbacks (using SDK's bsp_set_btn_* interface)             */
-/* ------------------------------------------------------------------ */
 
 static void on_button_multi_click_restart(void) {
     ESP_LOGW(TAG, "Button %d-click - REBOOTING!", RESTART_CLICK_COUNT);
@@ -209,27 +230,6 @@ static void log_heap_state(const char *stage) {
              (unsigned)(largest_spiram / 1024U));
 }
 
-static int ensure_boot_wifi_connection(void) {
-    char saved_ssid[33] = {0};
-    if (wifi_has_credentials() != 1) {
-        ESP_LOGI(TAG, "No stored WiFi credentials found");
-        return -1;
-    }
-
-    if (wifi_get_saved_ssid(saved_ssid, sizeof(saved_ssid)) == 0) {
-        ESP_LOGI(TAG, "Connecting to stored WiFi SSID: %s", saved_ssid);
-    } else {
-        ESP_LOGI(TAG, "Connecting to stored WiFi credentials");
-    }
-
-    if (wifi_connect_async() == 0) {
-        return 0;
-    }
-
-    ESP_LOGW(TAG, "Unable to start WiFi background connect, continuing with BLE-only local control");
-    return -1;
-}
-
 static void wait_for_behavior_idle(uint32_t timeout_ms) {
     uint32_t waited_ms = 0;
 
@@ -244,12 +244,12 @@ static void wait_for_behavior_idle(uint32_t timeout_ms) {
 }
 
 static idle_hint_mode_t get_idle_hint_mode(void) {
-    if (ble_service_is_connected() && wifi_is_connected() != 1) {
-        return IDLE_HINT_BLE_NO_WIFI;
+    if (s_transport_state == TRANSPORT_BLE_IDLE_CLOUD_READY) {
+        return IDLE_HINT_READY;
     }
 
-    if (s_cloud_session_configured && wifi_is_connected() == 1) {
-        return IDLE_HINT_READY;
+    if (ble_service_is_connected() || wifi_has_credentials() != 1) {
+        return IDLE_HINT_BLE_NO_WIFI;
     }
 
     return IDLE_HINT_BLE_READY;
@@ -287,13 +287,344 @@ static void apply_idle_hint_if_needed(void) {
     s_hint_initialized = true;
 }
 
-/* ------------------------------------------------------------------ */
-/* Main Application                                                   */
-/* ------------------------------------------------------------------ */
+static void ensure_cloud_runtime_started(void) {
+    if (!s_boot_completed || s_cloud_runtime_started) {
+        return;
+    }
+
+    if (hal_display_input_init() != 0) {
+        ESP_LOGW(TAG, "Delayed display input initialization failed");
+    }
+
+    if (hal_display_has_knob_input()) {
+        bsp_set_btn_multi_click_cb(RESTART_CLICK_COUNT, on_button_multi_click_restart);
+    } else {
+        ESP_LOGW(TAG, "Skipping %d-click restart callback because knob input is unavailable", RESTART_CLICK_COUNT);
+    }
+
+    voice_recorder_init();
+    if (voice_recorder_start() != 0) {
+        ESP_LOGE(TAG, "Failed to start voice recorder (non-fatal)");
+    }
+
+    s_cloud_runtime_started = true;
+}
+
+static void transport_stop_ws(const char *reason) {
+    if (ws_client_is_started() || ws_client_is_connected() || ws_client_is_session_ready()) {
+        ESP_LOGI(TAG, "Stopping WebSocket transport (%s)", reason ? reason : "no reason");
+        ws_client_stop();
+    }
+}
+
+static void transport_discovery_task(void *arg) {
+    discovery_result_t result = {0};
+    uint32_t *generation = (uint32_t *)arg;
+
+    result.generation = generation ? *generation : 0;
+    result.status = discovery_start_with_timeout(&result.info, CLOUD_DISCOVERY_TIMEOUT_MS);
+
+    if (s_discovery_result_queue != NULL) {
+        (void)xQueueOverwrite(s_discovery_result_queue, &result);
+    }
+
+    s_discovery_inflight = false;
+    free(generation);
+    vTaskDelete(NULL);
+}
+
+static int transport_launch_discovery(void) {
+    BaseType_t task_ret;
+    uint32_t *generation;
+
+    if (s_discovery_inflight) {
+        return 0;
+    }
+
+    if (s_discovery_result_queue == NULL) {
+        s_discovery_result_queue = xQueueCreate(1, sizeof(discovery_result_t));
+        if (s_discovery_result_queue == NULL) {
+            ESP_LOGE(TAG, "Failed to create discovery result queue");
+            return -1;
+        }
+    }
+
+    generation = (uint32_t *)malloc(sizeof(uint32_t));
+    if (generation == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate discovery generation");
+        return -1;
+    }
+
+    s_discovery_generation += 1U;
+    *generation = s_discovery_generation;
+    s_discovery_inflight = true;
+
+    task_ret = xTaskCreate(transport_discovery_task,
+                           "cloud_discovery",
+                           4096,
+                           generation,
+                           5,
+                           NULL);
+    if (task_ret != pdPASS) {
+        s_discovery_inflight = false;
+        free(generation);
+        ESP_LOGE(TAG, "Failed to create discovery task");
+        return -1;
+    }
+
+    ESP_LOGI(TAG, "Started discovery generation %lu", (unsigned long)*generation);
+    transport_set_state(TRANSPORT_BLE_IDLE_DISCOVERING, "discovery task launched");
+    return 0;
+}
+
+static void transport_cancel_discovery(const char *reason) {
+    if (!s_discovery_inflight) {
+        return;
+    }
+
+    s_discovery_generation += 1U;
+    ESP_LOGI(TAG, "Discovery invalidated (%s)", reason ? reason : "no reason");
+}
+
+static int transport_prepare_ws_client(const char *ws_url) {
+    if (ws_url == NULL || ws_url[0] == '\0') {
+        return -1;
+    }
+
+    if (!s_ws_router_ready) {
+        ws_router_t router;
+
+        ws_handlers_init();
+        router = ws_handlers_get_router();
+        ws_router_init(&router);
+        s_ws_router_ready = true;
+    }
+
+    if (!s_ws_stack_ready || strcmp(ws_client_get_server_url(), ws_url) != 0) {
+        if (s_ws_stack_ready) {
+            transport_stop_ws("ws url refresh");
+            ws_client_deinit();
+            s_ws_stack_ready = false;
+        }
+
+        if (ws_client_set_server_url(ws_url) != 0) {
+            ESP_LOGE(TAG, "Failed to set WebSocket URL: %s", ws_url);
+            return -1;
+        }
+
+        if (ws_client_init() != 0) {
+            ESP_LOGE(TAG, "Failed to initialize WebSocket client");
+            return -1;
+        }
+
+        s_ws_stack_ready = true;
+    }
+
+    return 0;
+}
+
+static void transport_begin_wifi_resume(const char *reason) {
+    if (wifi_has_credentials() != 1) {
+        s_waiting_for_wifi_provision = true;
+        transport_stop_ws("missing credentials");
+        transport_set_state(TRANSPORT_BLE_IDLE_NO_CREDENTIALS, reason);
+        return;
+    }
+
+    s_waiting_for_wifi_provision = false;
+
+    if (wifi_is_connected() == 1) {
+        return;
+    }
+
+    if (wifi_is_connect_requested() == 1) {
+        transport_set_state(wifi_sta_is_started() == 1
+                                ? TRANSPORT_BLE_IDLE_WIFI_CONNECTING
+                                : TRANSPORT_BLE_IDLE_WIFI_STARTING,
+                            reason);
+        return;
+    }
+
+    if (wifi_resume_background() == 0) {
+        transport_set_state(wifi_sta_is_started() == 1
+                                ? TRANSPORT_BLE_IDLE_WIFI_CONNECTING
+                                : TRANSPORT_BLE_IDLE_WIFI_STARTING,
+                            reason);
+        return;
+    }
+
+    transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+    transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "wifi resume failed");
+}
+
+static void transport_handle_discovery_results(bool ble_connected) {
+    discovery_result_t result;
+
+    if (s_discovery_result_queue == NULL) {
+        return;
+    }
+
+    while (xQueueReceive(s_discovery_result_queue, &result, 0) == pdTRUE) {
+        char *ws_url = NULL;
+
+        if (result.generation != s_discovery_generation) {
+            ESP_LOGI(TAG,
+                     "Ignoring stale discovery result generation %lu (current %lu)",
+                     (unsigned long)result.generation,
+                     (unsigned long)s_discovery_generation);
+            continue;
+        }
+
+        if (ble_connected) {
+            ESP_LOGI(TAG, "Ignoring discovery result because BLE is active");
+            continue;
+        }
+
+        if (result.status != 0) {
+            ESP_LOGW(TAG, "Discovery failed, retrying after %u ms", CLOUD_RETRY_DELAY_MS);
+            transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "discovery failed");
+            continue;
+        }
+
+        if (result.info.protocol_version[0] == '\0' ||
+            strcmp(result.info.protocol_version, WATCHER_PROTOCOL_VERSION) != 0) {
+            ESP_LOGE(TAG,
+                     "Protocol mismatch: server=%s expected=%s",
+                     result.info.protocol_version[0] != '\0' ? result.info.protocol_version : "<missing>",
+                     WATCHER_PROTOCOL_VERSION);
+            transport_schedule_retry(CLOUD_PROTOCOL_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "protocol mismatch");
+            continue;
+        }
+
+        ESP_LOGI(TAG,
+                 "Discovery ready: %s:%u protocol=%s",
+                 result.info.ip,
+                 result.info.port,
+                 result.info.protocol_version);
+
+        ws_url = discovery_get_ws_url(&result.info);
+        if (ws_url == NULL) {
+            ESP_LOGE(TAG, "Failed to build WebSocket URL from discovery result");
+            transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "ws url build failed");
+            continue;
+        }
+
+        if (transport_prepare_ws_client(ws_url) != 0) {
+            free(ws_url);
+            transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "ws prepare failed");
+            continue;
+        }
+
+        free(ws_url);
+        ensure_cloud_runtime_started();
+
+        if (ws_client_start() != 0) {
+            transport_stop_ws("ws start failed");
+            transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "ws start failed");
+            continue;
+        }
+
+        transport_schedule_retry(0);
+        log_heap_state("after_ws_start");
+        transport_set_state(TRANSPORT_BLE_IDLE_WS_CONNECTING, "ws start requested");
+    }
+}
+
+static void transport_suspend_for_ble(void) {
+    ESP_LOGI(TAG, "BLE connected, pausing WiFi/WS background activity");
+    transport_cancel_discovery("ble connected");
+    transport_stop_ws("ble connected");
+    wifi_suspend_for_ble();
+    transport_schedule_retry(0);
+    transport_set_state(TRANSPORT_BLE_ACTIVE, "ble connected");
+}
+
+static void transport_coordinator_tick(void) {
+    bool ble_connected = ble_service_is_connected();
+
+    transport_handle_discovery_results(ble_connected);
+
+    if (ble_connected != s_last_ble_connected) {
+        s_last_ble_connected = ble_connected;
+
+        if (ble_connected) {
+            transport_suspend_for_ble();
+            return;
+        }
+
+        ESP_LOGI(TAG, "BLE disconnected, allowing WiFi/WS recovery");
+        transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "ble disconnected");
+    }
+
+    if (ble_connected) {
+        transport_set_state(TRANSPORT_BLE_ACTIVE, "ble still connected");
+        return;
+    }
+
+    if (wifi_has_credentials() != 1) {
+        s_waiting_for_wifi_provision = true;
+        transport_stop_ws("credentials cleared");
+        transport_set_state(TRANSPORT_BLE_IDLE_NO_CREDENTIALS, "no credentials");
+        return;
+    }
+
+    if (wifi_is_connected() != 1) {
+        transport_stop_ws("wifi not connected");
+
+        if (transport_retry_due()) {
+            transport_begin_wifi_resume("wifi recovery");
+        } else {
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "waiting wifi retry");
+        }
+        return;
+    }
+
+    s_waiting_for_wifi_provision = false;
+
+    if (!s_discovery_initialized) {
+        if (discovery_init() == 0) {
+            s_discovery_initialized = true;
+        } else {
+            ESP_LOGW(TAG, "Discovery init failed, retrying later");
+            transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+            transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "discovery init failed");
+            return;
+        }
+    }
+
+    if (ws_client_is_session_ready()) {
+        transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_READY, "ws session ready");
+        return;
+    }
+
+    if (ws_client_is_connected() || ws_client_is_started()) {
+        transport_set_state(TRANSPORT_BLE_IDLE_WS_CONNECTING, "ws connecting");
+        return;
+    }
+
+    if (s_discovery_inflight) {
+        transport_set_state(TRANSPORT_BLE_IDLE_DISCOVERING, "discovery in flight");
+        return;
+    }
+
+    if (!transport_retry_due()) {
+        transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "waiting cloud retry");
+        return;
+    }
+
+    if (transport_launch_discovery() != 0) {
+        transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+        transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "discovery launch failed");
+    }
+}
 
 void app_main(void) {
     ESP_LOGI(TAG, "WatcheRobot S3 v2.0 starting");
-    bool cloud_ready = false;
 
     /* 1. Minimal display init for boot animation */
     if (hal_display_minimal_init() != 0) {
@@ -328,129 +659,68 @@ void app_main(void) {
     boot_anim_set_text("State...");
     behavior_state_init();
 
-    esp_err_t ingress_ret = control_ingress_init();
-    if (ingress_ret != ESP_OK) {
-        ESP_LOGE(TAG, "Control ingress init failed: %s", esp_err_to_name(ingress_ret));
+    if (control_ingress_init() != ESP_OK) {
+        ESP_LOGE(TAG, "Control ingress init failed");
         return;
     }
 
     /* 5.5 BLE control + provisioning */
     boot_anim_set_progress(35);
     boot_anim_set_text("BLE...");
-    esp_err_t ble_ret = ble_service_init();
-    if (ble_ret == ESP_OK) {
-        ble_ret = ble_service_start_advertising();
-        if (ble_ret != ESP_OK) {
-            ESP_LOGW(TAG, "BLE advertising start failed: %s", esp_err_to_name(ble_ret));
+    {
+        esp_err_t ble_ret = ble_service_init();
+        if (ble_ret == ESP_OK) {
+            ble_ret = ble_service_start_advertising();
+            if (ble_ret != ESP_OK) {
+                ESP_LOGW(TAG, "BLE advertising start failed: %s", esp_err_to_name(ble_ret));
+            }
+        } else if (ble_ret != ESP_ERR_NOT_SUPPORTED) {
+            ESP_LOGW(TAG, "BLE init failed: %s", esp_err_to_name(ble_ret));
         }
-    } else if (ble_ret != ESP_ERR_NOT_SUPPORTED) {
-        ESP_LOGW(TAG, "BLE init failed: %s", esp_err_to_name(ble_ret));
     }
     log_heap_state("after_ble_init");
 
-    /* 6. WiFi */
+    /* 6. WiFi manager only; cloud link is coordinated after boot. */
     boot_anim_set_progress(40);
     boot_anim_set_text("WiFi...");
     wifi_init();
     wifi_register_status_callback(on_wifi_status_changed);
-    if (ensure_boot_wifi_connection() != 0) {
+    if (wifi_has_credentials() == 1 && !ble_service_is_connected()) {
+        if (wifi_resume_background() == 0) {
+            ESP_LOGI(TAG, "Boot WiFi resume accepted; cloud coordinator will continue after boot");
+        } else {
+            s_waiting_for_wifi_provision = true;
+            boot_anim_set_text("BLE Ready");
+            ESP_LOGI(TAG, "Unable to resume WiFi at boot, continuing with BLE-only local control");
+        }
+    } else {
         s_waiting_for_wifi_provision = true;
         boot_anim_set_text("BLE Ready");
-        ESP_LOGI(TAG, "BLE local control is ready without WiFi/WebSocket");
-    } else {
-        ESP_LOGI(TAG, "WiFi connect is running in background; BLE local control remains available");
+        ESP_LOGI(TAG, "BLE local control is ready without immediate cloud bring-up");
     }
     boot_anim_set_progress(55);
     log_heap_state("after_wifi_ready");
 
-    /* 7. Service discovery */
-    if (wifi_is_connected() == 1) {
-        boot_anim_set_text("Discovering...");
-        discovery_init();
-        server_info_t server_info = {0};
-        if (discovery_start_with_timeout(&server_info, BOOT_DISCOVERY_TIMEOUT_MS) == 0) {
-            if (server_info.protocol_version[0] == '\0' ||
-                strcmp(server_info.protocol_version, WATCHER_PROTOCOL_VERSION) != 0) {
-                ESP_LOGE(TAG, "Protocol mismatch: server=%s expected=%s",
-                         server_info.protocol_version[0] != '\0' ? server_info.protocol_version : "<missing>",
-                         WATCHER_PROTOCOL_VERSION);
-                boot_anim_show_error("Protocol Mismatch");
-                return;
-            }
-
-            ESP_LOGI(TAG, "Server: %s:%u protocol=%s", server_info.ip, server_info.port, server_info.protocol_version);
-            boot_anim_set_progress(65);
-            char *ws_url = discovery_get_ws_url(&server_info);
-            if (ws_url) {
-                ws_client_set_server_url(ws_url);
-                free(ws_url);
-                cloud_ready = true;
-                s_cloud_session_configured = true;
-            }
-        } else {
-            ESP_LOGW(TAG, "Discovery failed within %d ms, continuing in BLE-only mode", BOOT_DISCOVERY_TIMEOUT_MS);
-        }
-    } else {
-        ESP_LOGI(TAG, "Skipping discovery until WiFi is connected; BLE local control continues immediately");
-    }
-    log_heap_state("after_discovery");
-
-    if (cloud_ready) {
-        /* 8. WebSocket client */
-        boot_anim_set_progress(92);
-        boot_anim_set_text("Connecting...");
-        ws_client_init();
-        ws_handlers_init();
-        ws_router_t router = ws_handlers_get_router();
-        ws_router_init(&router);
-    } else {
-        boot_anim_set_progress(100);
-        boot_anim_set_text("BLE Ready");
-        s_ble_only_mode = true;
-    }
-
-    /* 9. Ready! */
-    if (cloud_ready) {
-        boot_anim_set_progress(100);
-        boot_anim_set_text("Ready!");
-    }
+    /* 7. Ready for UI; cloud transport is resumed by the coordinator loop. */
+    boot_anim_set_progress(100);
+    boot_anim_set_text("BLE Ready");
     vTaskDelay(pdMS_TO_TICKS(500));
     boot_anim_finish();
+    s_boot_completed = true;
     s_waiting_for_wifi_provision = false;
+
     log_heap_state("before_ui_init");
     hal_display_ui_init();
-    if (cloud_ready) {
-        if (hal_display_input_init() != 0) {
-            ESP_LOGW(TAG, "Delayed display input initialization failed");
-        }
-
-        /* Register encoder callbacks only after delayed input devices are attached. */
-        if (hal_display_has_knob_input()) {
-            bsp_set_btn_multi_click_cb(RESTART_CLICK_COUNT, on_button_multi_click_restart);
-        } else {
-            ESP_LOGW(TAG, "Skipping %d-click restart callback because knob input is unavailable", RESTART_CLICK_COUNT);
-        }
-
-        voice_recorder_init();
-        if (voice_recorder_start() != 0) {
-            ESP_LOGE(TAG, "Failed to start voice recorder (non-fatal)");
-        }
-    }
-
     behavior_state_set("boot");
     wait_for_behavior_idle(STARTUP_BEHAVIOR_TIMEOUT_MS);
-    behavior_state_set_text_style(cloud_ready ? "Ready!" : "BLE Ready", 0, false);
+    behavior_state_set_text_style("BLE Ready", 0, false);
     apply_idle_hint_if_needed();
     log_heap_state("after_ui_init");
-    if (cloud_ready) {
-        ws_client_start();
-        log_heap_state("after_ws_start");
-    }
+
     run_camera_boot_diag();
     log_heap_state("after_camera_diag");
-    /* Note: hal_display_ui_init() already sets "Ready" text and starts default animation.
-     * Don't call display_update here as it would override the startup UI state. */
-    ESP_LOGI(TAG, "WatcheRobot ready (cloud=%s, ble=%s)", cloud_ready ? "online" : "offline",
+    ESP_LOGI(TAG, "WatcheRobot ready (transport=%s, ble=%s)",
+             transport_state_to_string(s_transport_state),
              ble_service_is_connected() ? "connected" : "advertising");
 
     /* 10. Mark OTA partition valid (prevent rollback after successful boot) */
@@ -460,7 +730,7 @@ void app_main(void) {
     esp_task_wdt_add(NULL);
     while (1) {
         esp_task_wdt_reset();
-        handle_ble_transport_gate(ble_service_is_connected());
+        transport_coordinator_tick();
         apply_idle_hint_if_needed();
         ws_tts_timeout_check();
         vTaskDelay(pdMS_TO_TICKS(100));

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -39,6 +39,8 @@
 #define CLOUD_DISCOVERY_TIMEOUT_MS 5000
 #define CLOUD_RETRY_DELAY_MS 2000
 #define CLOUD_PROTOCOL_RETRY_DELAY_MS 5000
+#define WIFI_RESUME_MIN_INTERNAL_FREE_BYTES (28U * 1024U)
+#define WIFI_RESUME_MIN_INTERNAL_LARGEST_BYTES (16U * 1024U)
 #define CAMERA_DIAG_MIN_INTERNAL_FREE_BYTES (48U * 1024U)
 #define CAMERA_DIAG_MIN_INTERNAL_LARGEST_BYTES (16U * 1024U)
 #ifdef CONFIG_WATCHER_ANIM_FPS
@@ -60,9 +62,18 @@ typedef enum {
 
 typedef enum {
     IDLE_HINT_READY = 0,
-    IDLE_HINT_BLE_READY,
-    IDLE_HINT_BLE_NO_WIFI,
+    IDLE_HINT_BLE_CONNECTED,
+    IDLE_HINT_WIFI_SETUP_REQUIRED,
+    IDLE_HINT_WIFI_RECOVERING,
+    IDLE_HINT_WIFI_FAILED,
+    IDLE_HINT_CLOUD_CONNECTING,
 } idle_hint_mode_t;
+
+typedef struct {
+    const char *text;
+    int font_size;
+    bool alert;
+} idle_hint_view_t;
 
 typedef struct {
     uint32_t generation;
@@ -77,6 +88,7 @@ static bool s_ws_router_ready = false;
 static bool s_ws_stack_ready = false;
 static bool s_discovery_initialized = false;
 static bool s_last_ble_connected = false;
+static bool s_wifi_failed_since_last_success = false;
 static transport_state_t s_transport_state = TRANSPORT_BLE_IDLE_NO_CREDENTIALS;
 static volatile bool s_discovery_inflight = false;
 static uint32_t s_discovery_generation = 0;
@@ -126,6 +138,38 @@ static bool transport_retry_due(void) {
     return s_next_cloud_attempt_us == 0 || esp_timer_get_time() >= s_next_cloud_attempt_us;
 }
 
+static void on_ble_connection_changed(bool connected);
+
+static bool transport_has_wifi_resume_headroom(void)
+{
+    size_t free_internal = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t largest_internal = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+
+    if (free_internal < WIFI_RESUME_MIN_INTERNAL_FREE_BYTES ||
+        largest_internal < WIFI_RESUME_MIN_INTERNAL_LARGEST_BYTES) {
+        ESP_LOGW(TAG,
+                 "Deferring WiFi resume due to low internal heap: free=%u largest=%u",
+                 (unsigned)free_internal,
+                 (unsigned)largest_internal);
+        return false;
+    }
+
+    return true;
+}
+
+static void transport_sync_boot_state(void)
+{
+    s_last_ble_connected = ble_service_is_connected();
+
+    if (s_last_ble_connected) {
+        s_transport_state = TRANSPORT_BLE_ACTIVE;
+    } else if (wifi_has_credentials() == 1) {
+        s_transport_state = TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED;
+    } else {
+        s_transport_state = TRANSPORT_BLE_IDLE_NO_CREDENTIALS;
+    }
+}
+
 #if CONFIG_WATCHER_CAMERA_BOOT_DIAG
 static bool has_internal_heap_headroom(size_t min_free_bytes, size_t min_largest_block_bytes) {
     size_t free_internal = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
@@ -140,30 +184,35 @@ static void on_wifi_status_changed(wifi_status_t status, const char *ssid, const
     case WIFI_STATUS_CONNECTED:
         ESP_LOGI(TAG, "WiFi connected: ssid=%s ip=%s", ssid ? ssid : "<unknown>",
                  ip_addr ? ip_addr : "<no-ip>");
+        s_wifi_failed_since_last_success = false;
         if (!s_boot_completed && s_waiting_for_wifi_provision) {
-            boot_anim_set_text("WiFi Connected");
+            boot_anim_set_text("Wi-Fi connected");
         }
         break;
 
     case WIFI_STATUS_CONNECTING:
         ESP_LOGI(TAG, "WiFi connecting: ssid=%s", ssid ? ssid : "<unknown>");
         if (!s_boot_completed && s_waiting_for_wifi_provision) {
-            boot_anim_set_text("Connecting WiFi...");
+            boot_anim_set_text("Connecting Wi-Fi...");
         }
         break;
 
     case WIFI_STATUS_DISCONNECTED:
         ESP_LOGW(TAG, "WiFi connect failed or disconnected: ssid=%s", ssid ? ssid : "<unknown>");
+        if (!ble_service_is_connected() && wifi_has_credentials() == 1) {
+            s_wifi_failed_since_last_success = true;
+        }
         if (!s_boot_completed && s_waiting_for_wifi_provision) {
-            boot_anim_set_text("WiFi Failed, Retry");
+            boot_anim_set_text("Wi-Fi failed");
         }
         break;
 
     case WIFI_STATUS_UNCONFIGURED:
     default:
         ESP_LOGI(TAG, "WiFi unconfigured");
+        s_wifi_failed_since_last_success = false;
         if (!s_boot_completed && s_waiting_for_wifi_provision) {
-            boot_anim_set_text("Open APP Set WiFi");
+            boot_anim_set_text("Reconnect BLE to set Wi-Fi");
         }
         break;
     }
@@ -244,21 +293,79 @@ static void wait_for_behavior_idle(uint32_t timeout_ms) {
 }
 
 static idle_hint_mode_t get_idle_hint_mode(void) {
+    if (ble_service_is_connected()) {
+        return IDLE_HINT_BLE_CONNECTED;
+    }
+
+    if (wifi_has_credentials() != 1) {
+        return IDLE_HINT_WIFI_SETUP_REQUIRED;
+    }
+
     if (s_transport_state == TRANSPORT_BLE_IDLE_CLOUD_READY) {
         return IDLE_HINT_READY;
     }
 
-    if (ble_service_is_connected() || wifi_has_credentials() != 1) {
-        return IDLE_HINT_BLE_NO_WIFI;
+    if (wifi_is_connected() == 1) {
+        return IDLE_HINT_CLOUD_CONNECTING;
     }
 
-    return IDLE_HINT_BLE_READY;
+    if (s_wifi_failed_since_last_success) {
+        return IDLE_HINT_WIFI_FAILED;
+    }
+
+    switch (s_transport_state) {
+    case TRANSPORT_BLE_IDLE_WIFI_STARTING:
+    case TRANSPORT_BLE_IDLE_WIFI_CONNECTING:
+    case TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED:
+        return IDLE_HINT_WIFI_RECOVERING;
+
+    case TRANSPORT_BLE_IDLE_DISCOVERING:
+    case TRANSPORT_BLE_IDLE_WS_CONNECTING:
+        return IDLE_HINT_CLOUD_CONNECTING;
+
+    case TRANSPORT_BLE_IDLE_NO_CREDENTIALS:
+        return IDLE_HINT_WIFI_SETUP_REQUIRED;
+
+    case TRANSPORT_BLE_ACTIVE:
+        return IDLE_HINT_BLE_CONNECTED;
+
+    case TRANSPORT_BLE_IDLE_CLOUD_READY:
+        return IDLE_HINT_READY;
+
+    default:
+        return IDLE_HINT_WIFI_RECOVERING;
+    }
+}
+
+static idle_hint_view_t get_idle_hint_view(idle_hint_mode_t mode)
+{
+    switch (mode) {
+    case IDLE_HINT_BLE_CONNECTED:
+        return (idle_hint_view_t){ .text = "BLE connected", .font_size = 0, .alert = false };
+
+    case IDLE_HINT_WIFI_SETUP_REQUIRED:
+        return (idle_hint_view_t){ .text = "Reconnect BLE to set Wi-Fi", .font_size = 20, .alert = true };
+
+    case IDLE_HINT_WIFI_RECOVERING:
+        return (idle_hint_view_t){ .text = "Reconnecting Wi-Fi...", .font_size = 22, .alert = false };
+
+    case IDLE_HINT_WIFI_FAILED:
+        return (idle_hint_view_t){ .text = "Wi-Fi failed. Reconnect BLE.", .font_size = 20, .alert = true };
+
+    case IDLE_HINT_CLOUD_CONNECTING:
+        return (idle_hint_view_t){ .text = "Connecting cloud...", .font_size = 22, .alert = false };
+
+    case IDLE_HINT_READY:
+    default:
+        return (idle_hint_view_t){ .text = "Ready!", .font_size = 0, .alert = false };
+    }
 }
 
 static void apply_idle_hint_if_needed(void) {
     static idle_hint_mode_t s_last_applied_hint = IDLE_HINT_READY;
     static bool s_hint_initialized = false;
     idle_hint_mode_t desired_hint = get_idle_hint_mode();
+    idle_hint_view_t view = get_idle_hint_view(desired_hint);
 
     if (behavior_state_is_busy() || behavior_state_is_action_active()) {
         return;
@@ -268,20 +375,7 @@ static void apply_idle_hint_if_needed(void) {
         return;
     }
 
-    switch (desired_hint) {
-    case IDLE_HINT_BLE_NO_WIFI:
-        (void)behavior_state_set_with_text_style("standby", "BLE Ready but no WiFi", 24, true);
-        break;
-
-    case IDLE_HINT_READY:
-        (void)behavior_state_set_with_text_style("standby", "Ready!", 0, false);
-        break;
-
-    case IDLE_HINT_BLE_READY:
-    default:
-        (void)behavior_state_set_with_text_style("standby", "BLE Ready", 0, false);
-        break;
-    }
+    (void)behavior_state_set_with_text_style("standby", view.text, view.font_size, view.alert);
 
     s_last_applied_hint = desired_hint;
     s_hint_initialized = true;
@@ -437,6 +531,12 @@ static void transport_begin_wifi_resume(const char *reason) {
         return;
     }
 
+    if (!transport_has_wifi_resume_headroom()) {
+        transport_schedule_retry(CLOUD_RETRY_DELAY_MS);
+        transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "waiting heap headroom");
+        return;
+    }
+
     if (wifi_is_connect_requested() == 1) {
         transport_set_state(wifi_sta_is_started() == 1
                                 ? TRANSPORT_BLE_IDLE_WIFI_CONNECTING
@@ -537,11 +637,26 @@ static void transport_handle_discovery_results(bool ble_connected) {
 
 static void transport_suspend_for_ble(void) {
     ESP_LOGI(TAG, "BLE connected, pausing WiFi/WS background activity");
+    s_wifi_failed_since_last_success = false;
     transport_cancel_discovery("ble connected");
     transport_stop_ws("ble connected");
     wifi_suspend_for_ble();
     transport_schedule_retry(0);
     transport_set_state(TRANSPORT_BLE_ACTIVE, "ble connected");
+}
+
+static void on_ble_connection_changed(bool connected)
+{
+    s_last_ble_connected = connected;
+
+    if (connected) {
+        transport_suspend_for_ble();
+        return;
+    }
+
+    ESP_LOGI(TAG, "BLE disconnected, allowing WiFi/WS recovery");
+    transport_schedule_retry(0);
+    transport_set_state(TRANSPORT_BLE_IDLE_CLOUD_SUSPENDED, "ble disconnected");
 }
 
 static void transport_coordinator_tick(void) {
@@ -670,6 +785,7 @@ void app_main(void) {
     {
         esp_err_t ble_ret = ble_service_init();
         if (ble_ret == ESP_OK) {
+            ble_service_register_connection_callback(on_ble_connection_changed);
             ble_ret = ble_service_start_advertising();
             if (ble_ret != ESP_OK) {
                 ESP_LOGW(TAG, "BLE advertising start failed: %s", esp_err_to_name(ble_ret));
@@ -685,17 +801,13 @@ void app_main(void) {
     boot_anim_set_text("WiFi...");
     wifi_init();
     wifi_register_status_callback(on_wifi_status_changed);
-    if (wifi_has_credentials() == 1 && !ble_service_is_connected()) {
-        if (wifi_resume_background() == 0) {
-            ESP_LOGI(TAG, "Boot WiFi resume accepted; cloud coordinator will continue after boot");
-        } else {
-            s_waiting_for_wifi_provision = true;
-            boot_anim_set_text("BLE Ready");
-            ESP_LOGI(TAG, "Unable to resume WiFi at boot, continuing with BLE-only local control");
-        }
+    if (wifi_has_credentials() == 1) {
+        s_waiting_for_wifi_provision = false;
+        boot_anim_set_text("Preparing...");
+        ESP_LOGI(TAG, "Stored WiFi credentials detected; deferring WiFi resume until startup settles");
     } else {
         s_waiting_for_wifi_provision = true;
-        boot_anim_set_text("BLE Ready");
+        boot_anim_set_text("Reconnect BLE to set Wi-Fi");
         ESP_LOGI(TAG, "BLE local control is ready without immediate cloud bring-up");
     }
     boot_anim_set_progress(55);
@@ -706,8 +818,6 @@ void app_main(void) {
     boot_anim_set_text("BLE Ready");
     vTaskDelay(pdMS_TO_TICKS(500));
     boot_anim_finish();
-    s_boot_completed = true;
-    s_waiting_for_wifi_provision = false;
 
     log_heap_state("before_ui_init");
     hal_display_ui_init();
@@ -719,6 +829,8 @@ void app_main(void) {
 
     run_camera_boot_diag();
     log_heap_state("after_camera_diag");
+    s_boot_completed = true;
+    transport_sync_boot_state();
     ESP_LOGI(TAG, "WatcheRobot ready (transport=%s, ble=%s)",
              transport_state_to_string(s_transport_state),
              ble_service_is_connected() ? "connected" : "advertising");


### PR DESCRIPTION
## Summary
- refactor transport ownership into a BLE-priority coordinator for WiFi, discovery, and WebSocket recovery
- move BLE pause/resume handling onto connection callbacks and improve idle UI guidance during WiFi recovery failures
- remove noisy animation FPS logs and trim extra WiFi security profile diagnostics

## Testing
- idf.py fullclean
- idf.py build
- flashed earlier iterations to COM28 and COM37 during device checks
