### PR TITLE
[codex] add windows release flasher

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ idf.py build
 idf.py -p COM3 flash monitor
 ```
 
+### Windows Release ZIP Flasher
+
+For packaged Windows flashing without entering the ESP-IDF build flow:
+
+```powershell
+cd D:\GithubRep\WatcheRobot-Firmware
+python -m pip install -r tools\win_flasher\requirements.txt
+tools\flash-release.cmd
+```
+
+This CLI scans `firmware\s3\release\` for the newest release ZIP, lets you choose a COM port, parses `flash_args.txt`, and flashes the package with `esptool`.
+
+Useful commands:
+
+```powershell
+python -m tools.win_flasher list-releases
+python -m tools.win_flasher list-ports
+python -m tools.win_flasher flash --port COM41
+```
+
+Full usage is documented in [docs/development/windows-release-flasher.md](docs/development/windows-release-flasher.md).
+
 ### 4. Start the Cloud Server
 
 ```bash
@@ -164,6 +186,7 @@ WatcheRobot-Firmware/
 | [docs/development/known-issues.md](docs/development/known-issues.md) | Known issues & workarounds |
 | [docs/development/testing.md](docs/development/testing.md) | Testing guide |
 | [docs/development/codex-multi-device-workflow.md](docs/development/codex-multi-device-workflow.md) | Codex lane workflow for multi-feature / multi-device development |
+| [docs/development/windows-release-flasher.md](docs/development/windows-release-flasher.md) | Windows CLI flasher for packaged release ZIP files |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
 | [CHANGELOG.md](CHANGELOG.md) | Version history |
 

--- a/docs/development/windows-release-flasher.md
+++ b/docs/development/windows-release-flasher.md
@@ -1,0 +1,112 @@
+# Windows Release Flasher
+
+`tools\flash-release.cmd` is a Windows-first CLI for flashing packaged release ZIP files without entering the ESP-IDF build flow.
+
+## What It Does
+
+The tool is aimed at packaged firmware validation on Windows:
+
+1. Scan `firmware\s3\release\vX.Y.Z`
+2. Pick the newest valid ZIP by default
+3. Let you switch to another scanned release or a manual ZIP
+4. List COM ports and let you choose one
+5. Parse `flash_args.txt`
+6. Flash every segment with `esptool`
+7. Optionally open a short serial monitor
+
+It does not build firmware from source. The existing `firmware\s3\tools\flash-monitor.ps1` flow still owns source build plus `idf.py` flashing.
+
+## Run From The Repository Root
+
+Use the repository root as the working directory:
+
+```powershell
+cd D:\GithubRep\WatcheRobot-Firmware
+```
+
+If you are working from a Codex feature worktree, switch into that worktree root instead:
+
+```powershell
+cd C:\Users\50533\.codex\worktrees\53fc\WatcheRobot-Firmware
+```
+
+## Install Dependencies
+
+```powershell
+python -m pip install -r tools\win_flasher\requirements.txt
+```
+
+## Interactive Wizard
+
+This is the easiest path for day-to-day release flashing:
+
+```powershell
+tools\flash-release.cmd
+```
+
+The wizard will show the latest scanned release ZIP first, then let you confirm or override it before selecting a COM port.
+
+## Non-Interactive Commands
+
+List discovered release ZIP files:
+
+```powershell
+python -m tools.win_flasher list-releases
+```
+
+List current COM ports:
+
+```powershell
+python -m tools.win_flasher list-ports
+```
+
+Flash the latest scanned release ZIP to a specific port:
+
+```powershell
+python -m tools.win_flasher flash --port COM41
+```
+
+Flash a manually selected ZIP:
+
+```powershell
+python -m tools.win_flasher flash --zip C:\path\to\WatcheRobot-S3-v0.1.7-esp32s3.zip --port COM41
+```
+
+Flash and then open a short serial monitor:
+
+```powershell
+python -m tools.win_flasher flash --port COM41 --monitor --monitor-seconds 20
+```
+
+## Common Notes
+
+- The default flash baud is `460800`.
+- The default monitor baud is `115200`.
+- The CLI uses `flash_args.txt` inside the ZIP as the single source of truth for layout and flash options.
+- If multiple COM ports are present, use `list-ports` first and then pass `--port COMx` explicitly.
+
+## Troubleshooting
+
+`Could not open requirements file`
+
+- You are probably in the wrong directory or on the wrong worktree.
+- First run `pwd`, then make sure `tools\win_flasher\requirements.txt` exists under the current repository root.
+
+`未安装 esptool`
+
+- Install dependencies again:
+
+```powershell
+python -m pip install -r tools\win_flasher\requirements.txt
+```
+
+`未检测到可用串口`
+
+- Confirm the device is connected.
+- Run `python -m tools.win_flasher list-ports`.
+- If Windows assigned a different COM port than expected, pass it explicitly with `--port`.
+
+`检测到多个串口，请使用 --port`
+
+- This is expected when Bluetooth virtual ports and USB serial ports are both present.
+- Use `list-ports` to identify the correct USB serial device and then rerun with `--port COMx`.

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local Python tooling packages."""

--- a/tools/flash-release.cmd
+++ b/tools/flash-release.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+pushd "%~dp0.."
+python -m tools.win_flasher %*
+set EXIT_CODE=%ERRORLEVEL%
+popd
+exit /b %EXIT_CODE%

--- a/tools/win_flasher/__init__.py
+++ b/tools/win_flasher/__init__.py
@@ -1,0 +1,5 @@
+"""Windows release flasher for WatcheRobot firmware."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/win_flasher/__main__.py
+++ b/tools/win_flasher/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/win_flasher/cli.py
+++ b/tools/win_flasher/cli.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.table import Table
+
+from .flasher import FlashingError, flash_package, monitor_port
+from .package_parser import PackageParseError, parse_flash_package
+from .ports import PortInfo, list_serial_ports
+from .releases import get_latest_release, get_repo_root, scan_release_entries
+
+console = Console()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.win_flasher",
+        description="WatcheRobot Windows release flasher",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list-releases", help="List discovered release ZIP packages")
+    subparsers.add_parser("list-ports", help="List available Windows serial ports")
+
+    flash_parser = subparsers.add_parser("flash", help="Flash a release ZIP")
+    flash_parser.add_argument("--zip", dest="zip_path", help="Release ZIP path")
+    flash_parser.add_argument("--port", help="Serial port, e.g. COM7")
+    flash_parser.add_argument("--baud", type=int, default=460800, help="Flash baud rate")
+    flash_parser.add_argument("--monitor", action="store_true", help="Open short serial monitor after flashing")
+    flash_parser.add_argument(
+        "--monitor-seconds", type=int, default=15, help="Monitor duration in seconds"
+    )
+    flash_parser.add_argument(
+        "--monitor-baud", type=int, default=115200, help="Monitor baud rate"
+    )
+    return parser
+
+
+def _show_release_table(entries: list, title: str = "Release ZIPs") -> None:
+    table = Table(title=title)
+    table.add_column("#", justify="right")
+    table.add_column("Version")
+    table.add_column("ZIP")
+    table.add_column("Path")
+    for index, entry in enumerate(entries, start=1):
+        table.add_row(str(index), entry.version, entry.zip_name, str(entry.zip_path))
+    console.print(table)
+
+
+def _show_ports_table(ports: list[PortInfo], title: str = "Serial Ports") -> None:
+    table = Table(title=title)
+    table.add_column("#", justify="right")
+    table.add_column("Port")
+    table.add_column("Description")
+    table.add_column("VID:PID")
+    table.add_column("HWID")
+    for index, port in enumerate(ports, start=1):
+        vid_pid = ""
+        if port.vid is not None and port.pid is not None:
+            vid_pid = f"{port.vid:04X}:{port.pid:04X}"
+        table.add_row(str(index), port.device, port.description, vid_pid, port.hwid)
+    console.print(table)
+
+
+def _choose_release_zip() -> Path:
+    entries = scan_release_entries()
+    latest = entries[0] if entries else None
+
+    if latest is None:
+        manual_path = Prompt.ask("No scanned release ZIP found. Enter a ZIP path")
+        return Path(manual_path).expanduser().resolve()
+
+    _show_release_table(entries)
+    console.print(f"[green]Latest release:[/green] {latest.version} -> {latest.zip_path}")
+    console.print("1. Use latest release ZIP")
+    console.print("2. Choose another scanned release ZIP")
+    console.print("3. Enter a custom ZIP path")
+    choice = IntPrompt.ask("Select ZIP source", choices=["1", "2", "3"], default=1)
+
+    if choice == 1:
+        return latest.zip_path
+    if choice == 2:
+        selected = IntPrompt.ask("Enter release number", choices=[str(i) for i in range(1, len(entries) + 1)])
+        return entries[selected - 1].zip_path
+
+    manual_path = Prompt.ask("Enter ZIP path")
+    return Path(manual_path).expanduser().resolve()
+
+
+def _choose_port() -> str:
+    ports = list_serial_ports()
+    if not ports:
+        return Prompt.ask("No serial ports detected. Enter a COM port manually")
+
+    _show_ports_table(ports)
+    if len(ports) == 1:
+        default_port = ports[0].device
+        if Confirm.ask(f"Use the only detected port {default_port}?", default=True):
+            return default_port
+        return Prompt.ask("Enter a COM port manually", default=default_port)
+
+    selection_choices = [str(i) for i in range(1, len(ports) + 1)]
+    selected = IntPrompt.ask("Select COM port", choices=selection_choices, default=1)
+    return ports[selected - 1].device
+
+
+def _summarize_package(package) -> None:
+    table = Table(title="Flash Layout")
+    table.add_column("Offset")
+    table.add_column("File")
+    table.add_column("Size")
+    for segment in package.segments:
+        table.add_row(hex(segment.offset), segment.file_name, str(len(segment.data)))
+
+    console.print(
+        Panel.fit(
+            f"ZIP: {package.package_path}\n"
+            f"Version: {package.version or 'unknown'}\n"
+            f"Chip: {package.chip}\n"
+            f"Flash mode: {package.flash_mode}\n"
+            f"Flash freq: {package.flash_freq}\n"
+            f"Flash size: {package.flash_size}",
+            title="Package Summary",
+        )
+    )
+    console.print(table)
+
+
+def _auto_port_for_noninteractive() -> str:
+    ports = list_serial_ports()
+    if len(ports) == 1:
+        return ports[0].device
+    if not ports:
+        raise FlashingError("未检测到可用串口，请使用 --port 显式指定。")
+    raise FlashingError("检测到多个串口，请使用 --port 显式指定 COM 口。")
+
+
+def run_interactive() -> int:
+    console.print(Panel.fit("WatcheRobot Windows Release Flasher", style="bold cyan"))
+    try:
+        zip_path = _choose_release_zip()
+        package = parse_flash_package(zip_path)
+        _summarize_package(package)
+        port = _choose_port()
+        baud = IntPrompt.ask("Flash baud", default=460800)
+        enable_monitor = Confirm.ask("Open serial monitor after flashing?", default=False)
+        monitor_seconds = 15
+        if enable_monitor:
+            monitor_seconds = IntPrompt.ask("Monitor duration (seconds)", default=15)
+
+        if not Confirm.ask(f"Flash {zip_path.name} to {port}?", default=True):
+            console.print("[yellow]Cancelled.[/yellow]")
+            return 0
+
+        flash_package(package, port=port, baud=baud, console=console)
+        console.print("[green]Flashing completed successfully.[/green]")
+        if enable_monitor:
+            monitor_port(port=port, baud=115200, seconds=monitor_seconds, console=console)
+        return 0
+    except (PackageParseError, FlashingError, OSError) as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        return 1
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Cancelled by user.[/yellow]")
+        return 130
+
+
+def command_list_releases() -> int:
+    entries = scan_release_entries()
+    if not entries:
+        console.print("[yellow]No release ZIP packages found under firmware/s3/release.[/yellow]")
+        return 1
+    _show_release_table(entries)
+    console.print(f"[green]Latest:[/green] {entries[0].version} -> {entries[0].zip_path}")
+    return 0
+
+
+def command_list_ports() -> int:
+    ports = list_serial_ports()
+    if not ports:
+        console.print("[yellow]No serial ports detected.[/yellow]")
+        return 1
+    _show_ports_table(ports)
+    return 0
+
+
+def command_flash(args: argparse.Namespace) -> int:
+    try:
+        if args.zip_path:
+            zip_path = Path(args.zip_path).expanduser().resolve()
+        else:
+            latest = get_latest_release(get_repo_root())
+            if latest is None:
+                raise FlashingError("未扫描到 release ZIP，请使用 --zip 显式指定。")
+            zip_path = latest.zip_path
+
+        package = parse_flash_package(zip_path)
+        port = args.port or _auto_port_for_noninteractive()
+        _summarize_package(package)
+        flash_package(package, port=port, baud=args.baud, console=console)
+        console.print("[green]Flashing completed successfully.[/green]")
+        if args.monitor:
+            monitor_port(port=port, baud=args.monitor_baud, seconds=args.monitor_seconds, console=console)
+        return 0
+    except (PackageParseError, FlashingError, OSError) as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "list-releases":
+        return command_list_releases()
+    if args.command == "list-ports":
+        return command_list_ports()
+    if args.command == "flash":
+        return command_flash(args)
+    return run_interactive()

--- a/tools/win_flasher/flasher.py
+++ b/tools/win_flasher/flasher.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import serial
+from rich.console import Console
+
+from .models import ParsedFlashPackage
+
+
+class FlashingError(RuntimeError):
+    """Raised when flashing or monitoring fails."""
+
+
+def ensure_esptool_installed() -> None:
+    if importlib.util.find_spec("esptool") is None:
+        raise FlashingError(
+            "未安装 esptool。请先执行: python -m pip install -r tools\\win_flasher\\requirements.txt"
+        )
+
+
+def _write_segments_to_tempdir(package: ParsedFlashPackage, tempdir: Path) -> list[tuple[int, Path]]:
+    extracted: list[tuple[int, Path]] = []
+    for segment in package.segments:
+        file_name = f"{segment.offset:08x}-{segment.file_name}"
+        target_path = tempdir / file_name
+        target_path.write_bytes(segment.data)
+        extracted.append((segment.offset, target_path))
+    return extracted
+
+
+def build_esptool_command(
+    package: ParsedFlashPackage,
+    port: str,
+    baud: int,
+    extracted_segments: list[tuple[int, Path]],
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "esptool",
+        "--chip",
+        package.chip,
+        "-p",
+        port,
+        "-b",
+        str(baud),
+        "--before",
+        "default_reset",
+        "--after",
+        "hard_reset",
+        "write_flash",
+        "--flash_mode",
+        package.flash_mode,
+        "--flash_freq",
+        package.flash_freq,
+        "--flash_size",
+        package.flash_size,
+    ]
+
+    for offset, path in extracted_segments:
+        command.extend([hex(offset), str(path)])
+    return command
+
+
+def flash_package(package: ParsedFlashPackage, port: str, baud: int, console: Console) -> None:
+    ensure_esptool_installed()
+    with tempfile.TemporaryDirectory(prefix="watche-flash-") as temp_dir:
+        temp_path = Path(temp_dir)
+        extracted_segments = _write_segments_to_tempdir(package, temp_path)
+        command = build_esptool_command(package, port, baud, extracted_segments)
+
+        console.print(f"[cyan]Running:[/cyan] {' '.join(command)}")
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            console.print(line.rstrip())
+
+        return_code = process.wait()
+        if return_code != 0:
+            raise FlashingError(f"esptool 退出码非 0: {return_code}")
+
+
+def monitor_port(
+    port: str,
+    baud: int,
+    seconds: int,
+    console: Console,
+) -> None:
+    try:
+        with serial.Serial(port=port, baudrate=baud, timeout=0.2) as serial_port:
+            console.print(
+                f"[cyan]Monitoring {port} at {baud} baud for {seconds} seconds. Press Ctrl+C to stop.[/cyan]"
+            )
+            deadline = time.monotonic() + seconds
+            while time.monotonic() < deadline:
+                try:
+                    line = serial_port.readline()
+                except serial.SerialException as exc:
+                    raise FlashingError(f"串口读取失败: {exc}") from exc
+
+                if not line:
+                    continue
+
+                try:
+                    console.print(line.decode("utf-8", errors="replace").rstrip())
+                except UnicodeDecodeError:
+                    console.print(repr(line))
+    except serial.SerialException as exc:
+        raise FlashingError(f"无法打开串口 {port}: {exc}") from exc

--- a/tools/win_flasher/models.py
+++ b/tools/win_flasher/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReleaseEntry:
+    version: str
+    zip_path: Path
+    zip_name: str
+    release_dir: Path
+    notes_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class FlashSegment:
+    offset: int
+    path: str
+    file_name: str
+    data: bytes
+
+
+@dataclass(frozen=True)
+class ParsedFlashPackage:
+    package_path: Path
+    version: str | None
+    chip: str
+    flash_mode: str
+    flash_freq: str
+    flash_size: str
+    segments: list[FlashSegment]

--- a/tools/win_flasher/package_parser.py
+++ b/tools/win_flasher/package_parser.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from zipfile import ZipFile
+
+from .models import FlashSegment, ParsedFlashPackage
+
+REQUIRED_BINARIES = {"bootloader.bin", "partition-table.bin"}
+VERSION_IN_NAME = re.compile(r"(v\d+\.\d+\.\d+)")
+
+
+class PackageParseError(ValueError):
+    """Raised when a release zip cannot be parsed into flash segments."""
+
+
+def infer_version_from_path(package_path: Path) -> str | None:
+    candidates = [package_path.name, package_path.parent.name]
+    for candidate in candidates:
+        match = VERSION_IN_NAME.search(candidate)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _normalize_zip_name(name: str) -> str:
+    return name.replace("\\", "/").lstrip("./")
+
+
+def _find_zip_member(zf: ZipFile, requested_path: str) -> str:
+    normalized = _normalize_zip_name(requested_path)
+    names = zf.namelist()
+    normalized_map = {_normalize_zip_name(name): name for name in names}
+
+    if normalized in normalized_map:
+        return normalized_map[normalized]
+
+    basename = Path(normalized).name.lower()
+    basename_matches = [
+        original_name
+        for original_name in names
+        if Path(_normalize_zip_name(original_name)).name.lower() == basename
+    ]
+    if len(basename_matches) == 1:
+        return basename_matches[0]
+    if len(basename_matches) > 1:
+        raise PackageParseError(f"ZIP 内存在多个同名文件，无法唯一匹配: {requested_path}")
+
+    raise PackageParseError(f"ZIP 内缺少烧录文件: {requested_path}")
+
+
+def _load_flash_args(zf: ZipFile) -> str:
+    names = zf.namelist()
+    exact = [name for name in names if _normalize_zip_name(name).lower() == "flash_args.txt"]
+    if exact:
+        return zf.read(exact[0]).decode("utf-8")
+
+    basename_matches = [
+        name for name in names if Path(_normalize_zip_name(name)).name.lower() == "flash_args.txt"
+    ]
+    if len(basename_matches) == 1:
+        return zf.read(basename_matches[0]).decode("utf-8")
+    if len(basename_matches) > 1:
+        raise PackageParseError("ZIP 内存在多个 flash_args.txt，无法确定使用哪个。")
+
+    raise PackageParseError("ZIP 内缺少 flash_args.txt。")
+
+
+def parse_flash_package(package_path: Path) -> ParsedFlashPackage:
+    if not package_path.exists():
+        raise PackageParseError(f"ZIP 不存在: {package_path}")
+
+    with ZipFile(package_path) as zf:
+        flash_args_content = _load_flash_args(zf)
+        lines = [line.strip() for line in flash_args_content.splitlines() if line.strip()]
+        if len(lines) < 2:
+            raise PackageParseError("flash_args.txt 内容不完整。")
+
+        flag_tokens = shlex.split(lines[0])
+        flash_mode = "dio"
+        flash_freq = "80m"
+        flash_size = "16MB"
+
+        for index, token in enumerate(flag_tokens):
+            if token == "--flash_mode" and index + 1 < len(flag_tokens):
+                flash_mode = flag_tokens[index + 1]
+            elif token == "--flash_freq" and index + 1 < len(flag_tokens):
+                flash_freq = flag_tokens[index + 1]
+            elif token == "--flash_size" and index + 1 < len(flag_tokens):
+                flash_size = flag_tokens[index + 1]
+
+        segments: list[FlashSegment] = []
+        basenames: set[str] = set()
+        for line in lines[1:]:
+            tokens = shlex.split(line)
+            if len(tokens) != 2:
+                raise PackageParseError(f"无法解析 flash_args 行: {line}")
+
+            try:
+                offset = int(tokens[0], 16)
+            except ValueError as exc:
+                raise PackageParseError(f"非法烧录地址: {tokens[0]}") from exc
+
+            member_name = _find_zip_member(zf, tokens[1])
+            file_name = Path(_normalize_zip_name(member_name)).name
+            data = zf.read(member_name)
+            segments.append(
+                FlashSegment(
+                    offset=offset,
+                    path=tokens[1],
+                    file_name=file_name,
+                    data=data,
+                )
+            )
+            basenames.add(file_name)
+
+        missing = sorted(REQUIRED_BINARIES - basenames)
+        if missing:
+            raise PackageParseError(f"ZIP 缺少必需二进制文件: {', '.join(missing)}")
+
+        if not any(segment.offset == 0x10000 and segment.file_name.lower().endswith(".bin") for segment in segments):
+            raise PackageParseError("ZIP 缺少主应用固件段（期望在 0x10000）。")
+
+        if not segments:
+            raise PackageParseError("flash_args.txt 未定义任何烧录 segment。")
+
+        return ParsedFlashPackage(
+            package_path=package_path,
+            version=infer_version_from_path(package_path),
+            chip="esp32s3",
+            flash_mode=flash_mode,
+            flash_freq=flash_freq,
+            flash_size=flash_size,
+            segments=segments,
+        )

--- a/tools/win_flasher/ports.py
+++ b/tools/win_flasher/ports.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from serial.tools import list_ports
+
+
+@dataclass(frozen=True)
+class PortInfo:
+    device: str
+    description: str
+    hwid: str
+    vid: int | None
+    pid: int | None
+
+
+def list_serial_ports() -> list[PortInfo]:
+    ports = [
+        PortInfo(
+            device=port.device,
+            description=port.description or "",
+            hwid=port.hwid or "",
+            vid=port.vid,
+            pid=port.pid,
+        )
+        for port in list_ports.comports()
+    ]
+
+    def sort_key(port: PortInfo) -> tuple[int, str]:
+        suffix = port.device.replace("COM", "")
+        if suffix.isdigit():
+            return (int(suffix), port.device)
+        return (9999, port.device)
+
+    return sorted(ports, key=sort_key)

--- a/tools/win_flasher/releases.py
+++ b/tools/win_flasher/releases.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .models import ReleaseEntry
+
+VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def get_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def get_release_root(repo_root: Path | None = None) -> Path:
+    root = repo_root or get_repo_root()
+    return root / "firmware" / "s3" / "release"
+
+
+def parse_version_key(version: str) -> tuple[int, int, int]:
+    match = VERSION_PATTERN.fullmatch(version)
+    if not match:
+        raise ValueError(f"Invalid release version: {version}")
+    return tuple(int(part) for part in match.groups())
+
+
+def _score_zip(version: str, zip_path: Path) -> tuple[int, int, str]:
+    name = zip_path.name.lower()
+    exact_version = int(version.lower() in name)
+    chip_hint = int("esp32s3" in name)
+    return (exact_version, chip_hint, name)
+
+
+def _pick_release_zip(version: str, release_dir: Path) -> Path | None:
+    zips = [path for path in release_dir.glob("*.zip") if path.is_file()]
+    if not zips:
+        return None
+    return sorted(zips, key=lambda path: _score_zip(version, path), reverse=True)[0]
+
+
+def scan_release_entries(repo_root: Path | None = None) -> list[ReleaseEntry]:
+    release_root = get_release_root(repo_root)
+    if not release_root.exists():
+        return []
+
+    entries: list[ReleaseEntry] = []
+    for release_dir in release_root.iterdir():
+        if not release_dir.is_dir():
+            continue
+        if not VERSION_PATTERN.fullmatch(release_dir.name):
+            continue
+
+        zip_path = _pick_release_zip(release_dir.name, release_dir)
+        if zip_path is None:
+            continue
+
+        notes_path = release_dir / "RELEASE_NOTES.md"
+        entries.append(
+            ReleaseEntry(
+                version=release_dir.name,
+                zip_path=zip_path,
+                zip_name=zip_path.name,
+                release_dir=release_dir,
+                notes_path=notes_path if notes_path.exists() else None,
+            )
+        )
+
+    return sorted(entries, key=lambda entry: parse_version_key(entry.version), reverse=True)
+
+
+def get_latest_release(repo_root: Path | None = None) -> ReleaseEntry | None:
+    entries = scan_release_entries(repo_root)
+    return entries[0] if entries else None

--- a/tools/win_flasher/requirements.txt
+++ b/tools/win_flasher/requirements.txt
@@ -1,0 +1,3 @@
+esptool
+pyserial
+rich

--- a/tools/win_flasher/tests/__init__.py
+++ b/tools/win_flasher/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Windows release flasher."""

--- a/tools/win_flasher/tests/test_package_parser.py
+++ b/tools/win_flasher/tests/test_package_parser.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from zipfile import ZipFile
+
+from tools.win_flasher.package_parser import PackageParseError, parse_flash_package
+from tools.win_flasher.releases import get_repo_root
+
+
+class PackageParserTests(unittest.TestCase):
+    def test_parse_existing_release_zip(self) -> None:
+        repo_root = get_repo_root()
+        package_path = repo_root / "firmware" / "s3" / "release" / "v0.1.7" / "WatcheRobot-S3-v0.1.7-esp32s3.zip"
+        package = parse_flash_package(package_path)
+
+        self.assertEqual(package.version, "v0.1.7")
+        self.assertEqual(package.chip, "esp32s3")
+        self.assertEqual(len(package.segments), 5)
+        self.assertEqual(package.segments[0].file_name, "bootloader.bin")
+
+    def test_missing_flash_args_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            zip_path = Path(temp_dir) / "bad.zip"
+            with ZipFile(zip_path, "w") as zf:
+                zf.writestr("bootloader.bin", b"boot")
+
+            with self.assertRaises(PackageParseError):
+                parse_flash_package(zip_path)
+
+    def test_basename_fallback_resolves_nested_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            zip_path = Path(temp_dir) / "fallback.zip"
+            with ZipFile(zip_path, "w") as zf:
+                zf.writestr(
+                    "flash_args.txt",
+                    "\n".join(
+                        [
+                            "--flash_mode dio --flash_freq 80m --flash_size 16MB",
+                            "0x0 bootloader/bootloader.bin",
+                            "0x8000 partition_table/partition-table.bin",
+                            "0x10000 app/WatcheRobot-S3.bin",
+                        ]
+                    ),
+                )
+                zf.writestr("bootloader.bin", b"boot")
+                zf.writestr("partition-table.bin", b"table")
+                zf.writestr("WatcheRobot-S3.bin", b"app")
+
+            package = parse_flash_package(zip_path)
+            self.assertEqual([segment.file_name for segment in package.segments], [
+                "bootloader.bin",
+                "partition-table.bin",
+                "WatcheRobot-S3.bin",
+            ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/win_flasher/tests/test_release_scanner.py
+++ b/tools/win_flasher/tests/test_release_scanner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+
+from tools.win_flasher.releases import get_latest_release, scan_release_entries
+
+
+class ReleaseScannerTests(unittest.TestCase):
+    def test_scans_and_sorts_releases(self) -> None:
+        entries = scan_release_entries()
+        versions = [entry.version for entry in entries[:4]]
+        self.assertEqual(versions, ["v0.1.7", "v0.1.6", "v0.1.5", "v0.1.3"])
+
+    def test_latest_release_is_v017(self) -> None:
+        latest = get_latest_release()
+        self.assertIsNotNone(latest)
+        assert latest is not None
+        self.assertEqual(latest.version, "v0.1.7")
+        self.assertTrue(latest.zip_path.name.endswith(".zip"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a Windows-first Python CLI for flashing packaged release ZIP files without entering the ESP-IDF build flow.

## What Changed

- add `tools/win_flasher/` as a repository-local Python package
- add `tools/flash-release.cmd` as a Windows entrypoint
- scan `firmware/s3/release/vX.Y.Z` and default to the newest valid ZIP
- parse `flash_args.txt` from release ZIPs and derive the flash layout from it
- add COM port discovery and interactive flashing flow
- add optional short serial monitoring after flashing
- document the workflow in `README.md` and `docs/development/windows-release-flasher.md`
- add unit tests for release scanning and ZIP parsing

## Why

Windows release validation needed a simpler packaged flashing path that does not depend on building firmware from source or manually reconstructing flash arguments.

## Validation

- `python -m unittest discover -s tools\\win_flasher\\tests -v`
- `python -m tools.win_flasher list-releases`
- `python -m tools.win_flasher list-ports`
- `python -m tools.win_flasher flash --port COM41` (verified preflight, stops with a clear install message when `esptool` is not yet installed)
