### PR TITLE
Fix action handoff latency and servo control interrupts

### DIFF
--- a/firmware/s3/components/hal/hal_servo/CHANGELOG.md
+++ b/firmware/s3/components/hal/hal_servo/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched the internal PWM mapping to the MS90 pulse model: `500..2500us`
   with `1500us` neutral while keeping public control angles in the existing
   `0..180` logical installation space (`90` remains neutral).
+- Raised the documented Y-axis soft limit to `170°` and aligned the README with
+  the current startup pose `X=90°`, `Y=120°`.
+- Behavior state changes and external manual control now cancel queued servo
+  motion so a new action does not have to wait for the previous loop to drain.
+
+### Added
+
+- Added `hal_servo_cancel_all()` to clear pending smooth-motion commands and
+  abort the current interpolation segment on the next step boundary.
+- Added `behavior_state_interrupt_action()` so BLE, WebSocket, and other manual
+  control paths can stop the active action loop before taking over the servos.
 
 ## [2.0.0] - 2025-03-13
 

--- a/firmware/s3/components/hal/hal_servo/README.md
+++ b/firmware/s3/components/hal/hal_servo/README.md
@@ -10,7 +10,7 @@ the firmware:
 - the HAL internally maps logical `90°` to the MS90 neutral pulse of `1500us`
 
 On startup, `hal_servo_init()` itself applies the default angles `X=90°` and
-`Y=90°`. Some behavior states later move Y to `120°`; that comes from the
+`Y=120°`. Some behavior states later move Y to other poses; that comes from the
 behavior resources, not from the HAL defaults.
 
 ## Overview
@@ -28,13 +28,15 @@ physical pulse model behind the existing firmware-facing logical angle model.
 - **Synchronized Motion**: Simultaneous dual-axis movement
 - **Mechanical Protection**: Y-axis limits prevent hardware damage
 - **Thread-Safe**: Mutex-protected angle access
+- **Motion Cancel**: Can discard queued motions and abort the current smooth
+  segment at the next interpolation step
 
 ## GPIO Mapping
 
 | Axis | GPIO | LEDC Channel | Logical Range |
 |------|------|--------------|---------------|
 | X (pan) | 19 | LEDC_TIMER_0, CH0 | 0-180°, neutral at 90° |
-| Y (tilt) | 20 | LEDC_TIMER_0, CH1 | 90-150° soft limit, neutral at 90° |
+| Y (tilt) | 20 | LEDC_TIMER_0, CH1 | 90-170° soft limit, neutral at 90° |
 
 ## API Reference
 
@@ -52,13 +54,13 @@ smooth-move background task. Must be called before any other servo functions.
 Immediately after `hal_servo_init()`, the current logical angles are:
 
 - `SERVO_AXIS_X`: `90°`
-- `SERVO_AXIS_Y`: `90°`
+- `SERVO_AXIS_Y`: `120°`
 
 Those values are also what the PWM outputs are configured to at boot, so
 `hal_servo_get_angle()` returns the expected current position right after
 initialization.
 
-After startup, the behavior layer may still command poses such as `Y=120°`
+After startup, the behavior layer may still command poses such as `Y=95°`
 through `states.json` or `spiffs/actions/*.json`. Those resources remain in the
 same logical angle space and are not rewritten by the HAL.
 
@@ -123,6 +125,18 @@ Get current logical servo angle.
 
 - Returns: Current logical angle in degrees, or -1 if not initialized
 
+### Cancel Queued Motion
+
+```c
+esp_err_t hal_servo_cancel_all(void);
+```
+
+Discard queued smooth-move commands and request the currently executing smooth
+segment to stop on its next interpolation step. This is intended for behavior
+state changes and external manual control handoff.
+
+- Returns: `ESP_OK` on success, `ESP_ERR_INVALID_STATE` if HAL not initialized
+
 ## Configuration (Kconfig)
 
 | Option | Default | Description |
@@ -130,7 +144,7 @@ Get current logical servo angle.
 | `WATCHER_SERVO_X_GPIO` | 19 | X-axis PWM output GPIO |
 | `WATCHER_SERVO_Y_GPIO` | 20 | Y-axis PWM output GPIO |
 | `WATCHER_SERVO_Y_MIN_DEG` | 90 | Y-axis mechanical minimum |
-| `WATCHER_SERVO_Y_MAX_DEG` | 150 | Y-axis mechanical maximum |
+| `WATCHER_SERVO_Y_MAX_DEG` | 170 | Y-axis mechanical maximum |
 | `WATCHER_SERVO_SMOOTH_STEP_MS` | 10 | Interpolation step interval |
 
 ## PWM Timing
@@ -157,7 +171,7 @@ Get current logical servo angle.
 
 void app_main(void)
 {
-    // Initialize servo HAL; startup defaults are X=90, Y=90
+    // Initialize servo HAL; startup defaults are X=90, Y=120
     ESP_ERROR_CHECK(hal_servo_init());
 
     // Smooth pan over 1 second
@@ -168,6 +182,9 @@ void app_main(void)
 
     // String-based command (for WebSocket handler)
     hal_servo_send_cmd("X", 135, 800);
+
+    // Abort queued smooth movement before manual handoff
+    hal_servo_cancel_all();
 
     // Query current position
     int x_angle = hal_servo_get_angle(SERVO_AXIS_X);
@@ -187,9 +204,9 @@ void app_main(void)
 
 ## Mechanical Limits
 
-The Y-axis has mechanical limits (default 90-150°) to prevent hardware damage.
-The HAL startup angle is 90°, and some behavior states later move the Y-axis to
-120° inside that same logical angle space. These limits are enforced
+The Y-axis has mechanical limits (default 90-170°) to prevent hardware damage.
+The HAL startup angle is 120°, and behavior states/actions later move the
+Y-axis inside that same logical angle space. These limits are enforced
 automatically:
 
 - `hal_servo_set_angle()`: Clamps Y-axis to limits

--- a/firmware/s3/components/hal/hal_servo/include/hal_servo.h
+++ b/firmware/s3/components/hal/hal_servo/include/hal_servo.h
@@ -97,6 +97,18 @@ esp_err_t hal_servo_move_sync(int x_deg, int y_deg, int duration_ms);
 esp_err_t hal_servo_send_cmd(const char *id, int angle_deg, int duration_ms);
 
 /**
+ * @brief Cancel in-flight and queued smooth servo motions.
+ *
+ * Clears the pending motion queue and asks the background interpolation task
+ * to stop the currently executing smooth segment on its next interpolation
+ * step boundary. This is used by higher-level behavior/state switching so a
+ * new action does not have to wait for the previous loop's queued motions.
+ *
+ * @return ESP_OK on success, ESP_ERR_INVALID_STATE if servo HAL is not ready
+ */
+esp_err_t hal_servo_cancel_all(void);
+
+/**
  * @brief Get current servo angle.
  *
  * @param axis Servo axis

--- a/firmware/s3/components/hal/hal_servo/src/hal_servo.c
+++ b/firmware/s3/components/hal/hal_servo/src/hal_servo.c
@@ -90,6 +90,8 @@ static TaskHandle_t s_servo_task = NULL;
 static SemaphoreHandle_t s_angle_mutex = NULL;
 static portMUX_TYPE s_cmd_seq_lock = portMUX_INITIALIZER_UNLOCKED;
 static uint32_t s_cmd_seq = 0;
+static portMUX_TYPE s_motion_cancel_lock = portMUX_INITIALIZER_UNLOCKED;
+static uint32_t s_motion_cancel_generation = 0;
 
 /* Forward declarations */
 static void servo_task(void *arg);
@@ -109,6 +111,8 @@ static void servo_log_enqueue(const servo_cmd_msg_t *cmd);
 static void servo_log_drop(const servo_cmd_msg_t *cmd, const char *reason);
 static void servo_log_execute_start(const servo_cmd_msg_t *cmd);
 static void servo_log_execute_done(const servo_cmd_msg_t *cmd, uint32_t exec_ms);
+static uint32_t servo_cancel_generation(void);
+static bool servo_cancel_requested(uint32_t generation);
 
 /**
  * @brief Divide and round to the nearest integer.
@@ -387,6 +391,20 @@ static void servo_log_execute_done(const servo_cmd_msg_t *cmd, uint32_t exec_ms)
              current_x, current_y, (unsigned long)servo_queue_depth());
 }
 
+static uint32_t servo_cancel_generation(void) {
+    uint32_t generation;
+
+    portENTER_CRITICAL(&s_motion_cancel_lock);
+    generation = s_motion_cancel_generation;
+    portEXIT_CRITICAL(&s_motion_cancel_lock);
+
+    return generation;
+}
+
+static bool servo_cancel_requested(uint32_t generation) {
+    return servo_cancel_generation() != generation;
+}
+
 /**
  * @brief Background task for smooth servo movement.
  *
@@ -409,6 +427,7 @@ static void servo_task(void *arg) {
 
         servo_log_execute_start(&cmd);
         uint32_t exec_started_ms = servo_now_ms();
+        uint32_t cancel_generation = servo_cancel_generation();
 
         if (cmd.type == CMD_TYPE_SINGLE) {
             /* Single-axis smooth move */
@@ -457,6 +476,12 @@ static void servo_task(void *arg) {
             /* Interpolate */
             for (int i = 1; i <= num_steps; i++) {
                 int current_deg;
+
+                if (servo_cancel_requested(cancel_generation)) {
+                    ESP_LOGI(TAG, "Abort servo cmd seq=%lu type=single due_to=cancel", (unsigned long)cmd.seq_no);
+                    break;
+                }
+
                 if (i == num_steps) {
                     current_deg = target_deg;
                 } else {
@@ -513,6 +538,11 @@ static void servo_task(void *arg) {
             /* Interpolate both axes */
             for (int i = 1; i <= num_steps; i++) {
                 int current_x, current_y;
+
+                if (servo_cancel_requested(cancel_generation)) {
+                    ESP_LOGI(TAG, "Abort servo cmd seq=%lu type=sync due_to=cancel", (unsigned long)cmd.seq_no);
+                    break;
+                }
 
                 if (i == num_steps) {
                     current_x = target_x;
@@ -729,6 +759,25 @@ esp_err_t hal_servo_send_cmd(const char *id, int angle_deg, int duration_ms) {
     }
 
     return hal_servo_move_smooth(axis, angle_deg, duration_ms);
+}
+
+esp_err_t hal_servo_cancel_all(void) {
+    servo_cmd_msg_t dropped;
+
+    if (!s_initialized || s_cmd_queue == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    portENTER_CRITICAL(&s_motion_cancel_lock);
+    s_motion_cancel_generation++;
+    portEXIT_CRITICAL(&s_motion_cancel_lock);
+
+    while (xQueueReceive(s_cmd_queue, &dropped, 0) == pdTRUE) {
+        servo_log_drop(&dropped, "cancel_all");
+    }
+
+    ESP_LOGI(TAG, "Canceled servo motions; q_depth=%lu", (unsigned long)servo_queue_depth());
+    return ESP_OK;
 }
 
 int hal_servo_get_angle(servo_axis_t axis) {

--- a/firmware/s3/components/protocols/ble_service/src/ble_service.c
+++ b/firmware/s3/components/protocols/ble_service/src/ble_service.c
@@ -24,6 +24,7 @@
 #include <strings.h>
 
 #include "control_ingress.h"
+#include "behavior_state_service.h"
 #include "esp_bt.h"
 #include "esp_mac.h"
 #include "esp_bt_main.h"
@@ -631,6 +632,15 @@ static void ble_send_text_notification(const char *text)
     }
 }
 
+static void ble_interrupt_action_before_servo(void)
+{
+    esp_err_t ret = behavior_state_interrupt_action("ble_servo_control");
+
+    if (ret != ESP_OK && ret != ESP_ERR_NOT_FOUND) {
+        ESP_LOGW(TAG, "BLE servo interrupt action failed: %s", esp_err_to_name(ret));
+    }
+}
+
 static esp_err_t ble_parse_and_send_servo(char axis, const char *payload)
 {
     control_servo_request_t req = {0};
@@ -658,6 +668,7 @@ static esp_err_t ble_parse_and_send_servo(char axis, const char *payload)
     req.x_deg = (int)angle;
     req.y_deg = (int)angle;
     req.duration_ms = duration_ms;
+    ble_interrupt_action_before_servo();
     return control_ingress_submit_servo(&req);
 }
 
@@ -716,6 +727,7 @@ static esp_err_t ble_parse_servo_move(const char *params)
     req.x_deg = target;
     req.y_deg = target;
     req.duration_ms = CONFIG_WATCHER_BLE_CMD_DEFAULT_DURATION_MS;
+    ble_interrupt_action_before_servo();
     return control_ingress_submit_servo(&req);
 }
 
@@ -852,6 +864,7 @@ static esp_err_t ble_process_json_payload(const char *json_text,
             return ESP_ERR_INVALID_ARG;
         }
 
+        ble_interrupt_action_before_servo();
         ret = control_ingress_submit_servo(&req);
         cJSON_Delete(root);
         if (ret == ESP_ERR_TIMEOUT) {

--- a/firmware/s3/components/services/behavior_state_service/include/behavior_state_service.h
+++ b/firmware/s3/components/services/behavior_state_service/include/behavior_state_service.h
@@ -30,6 +30,17 @@ const char *behavior_state_get_current(void);
 bool behavior_state_is_busy(void);
 bool behavior_state_has_action(const char *action_id);
 bool behavior_state_is_action_active(void);
+/**
+ * @brief Interrupt the currently active action motion track.
+ *
+ * Stops the behavior-layer action loop and asks the servo HAL to discard any
+ * queued motion segments that still belong to the interrupted action. The
+ * state itself can remain active; this only targets action motion playback.
+ *
+ * @param source Optional short source string for diagnostics/logging
+ * @return ESP_OK if an action was interrupted, ESP_ERR_NOT_FOUND if idle
+ */
+esp_err_t behavior_state_interrupt_action(const char *source);
 
 #ifdef __cplusplus
 }

--- a/firmware/s3/components/services/behavior_state_service/src/behavior_state_service.c
+++ b/firmware/s3/components/services/behavior_state_service/src/behavior_state_service.c
@@ -108,6 +108,7 @@ typedef struct {
     char current_state_id[BEHAVIOR_STATE_ID_LEN];
     char current_action_id[BEHAVIOR_STATE_ID_LEN];
     uint32_t state_started_ms;
+    uint32_t action_started_ms;
     int next_motion_index;
     int next_action_motion_index;
     int next_expression_index;
@@ -1211,6 +1212,7 @@ static void behavior_reset_runtime_locked(void) {
     behavior_copy_string(s_ctx.current_state_id, sizeof(s_ctx.current_state_id), s_ctx.catalog.default_state);
     s_ctx.current_action_id[0] = '\0';
     s_ctx.state_started_ms = behavior_now_ms();
+    s_ctx.action_started_ms = s_ctx.state_started_ms;
     s_ctx.next_motion_index = 0;
     s_ctx.next_action_motion_index = 0;
     s_ctx.next_expression_index = 0;
@@ -1333,8 +1335,40 @@ static void behavior_refresh_display_locked(behavior_display_request_t *request)
     behavior_capture_display_request_locked(request);
 }
 
+static bool behavior_stop_current_action_locked(const char *source) {
+    if (s_ctx.current_action == NULL) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "Interrupt action loop '%s' for state '%s' via %s",
+             s_ctx.current_action_id[0] != '\0' ? s_ctx.current_action_id : "<none>",
+             s_ctx.current_state_id[0] != '\0' ? s_ctx.current_state_id : s_ctx.catalog.default_state,
+             (source != NULL && source[0] != '\0') ? source : "external_control");
+
+    s_ctx.current_action = NULL;
+    s_ctx.current_action_id[0] = '\0';
+    s_ctx.next_action_motion_index = 0;
+    s_ctx.action_started_ms = behavior_now_ms();
+    if (hal_servo_cancel_all() != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to cancel servo motions while interrupting action");
+    }
+    return true;
+}
+
 static bool behavior_should_override_state_motion_locked(void) {
     return s_ctx.current_action != NULL;
+}
+
+static bool behavior_should_loop_action_locked(void) {
+    if (s_ctx.current_action == NULL || s_ctx.current_state == NULL) {
+        return false;
+    }
+
+    return s_ctx.current_state->loop || s_ctx.current_state->hold_until_replaced;
+}
+
+static uint32_t behavior_action_elapsed_ms_locked(uint32_t now_ms) {
+    return now_ms - s_ctx.action_started_ms;
 }
 
 static void behavior_log_action_start_locked(const char *state_id, const behavior_action_def_t *action_def) {
@@ -1431,12 +1465,14 @@ static bool behavior_all_action_events_dispatched_locked(void) {
 
 static void behavior_dispatch_due_events_locked(uint32_t now_ms, behavior_display_request_t *request) {
     uint32_t elapsed_ms;
+    uint32_t action_elapsed_ms;
 
     if (s_ctx.current_state == NULL) {
         return;
     }
 
     elapsed_ms = now_ms - s_ctx.state_started_ms;
+    action_elapsed_ms = behavior_action_elapsed_ms_locked(now_ms);
 
     if (!behavior_should_override_state_motion_locked()) {
         while (s_ctx.next_motion_index < s_ctx.current_state->motion_count &&
@@ -1447,7 +1483,7 @@ static void behavior_dispatch_due_events_locked(uint32_t now_ms, behavior_displa
     }
 
     while (s_ctx.current_action != NULL && s_ctx.next_action_motion_index < s_ctx.current_action->motion_count &&
-           s_ctx.current_action->motion[s_ctx.next_action_motion_index].at_ms <= elapsed_ms) {
+           s_ctx.current_action->motion[s_ctx.next_action_motion_index].at_ms <= action_elapsed_ms) {
         const behavior_motion_event_t *event = &s_ctx.current_action->motion[s_ctx.next_action_motion_index];
 
         ESP_LOGI(TAG, "Dispatch action '%s': at_ms=%lu x=%d y=%d duration_ms=%d",
@@ -1529,12 +1565,19 @@ static esp_err_t behavior_schedule_state_locked(const char *state_id, const char
             return ESP_OK;
         }
 
+        if (s_ctx.current_state != NULL || s_ctx.current_action != NULL) {
+            if (hal_servo_cancel_all() != ESP_OK) {
+                ESP_LOGW(TAG, "Failed to cancel servo motions before state/action switch");
+            }
+        }
+
         s_ctx.current_state = NULL;
         s_ctx.current_action = action_def;
         behavior_copy_string(s_ctx.current_state_id, sizeof(s_ctx.current_state_id), s_ctx.catalog.default_state);
         behavior_copy_string(s_ctx.current_action_id, sizeof(s_ctx.current_action_id),
                              action_def != NULL ? action_def->id : NULL);
         s_ctx.state_started_ms = now_ms;
+        s_ctx.action_started_ms = now_ms;
         s_ctx.next_motion_index = 0;
         s_ctx.next_action_motion_index = 0;
         s_ctx.next_expression_index = 0;
@@ -1581,12 +1624,19 @@ static esp_err_t behavior_schedule_state_locked(const char *state_id, const char
         return ESP_OK;
     }
 
+    if (s_ctx.current_state != NULL || s_ctx.current_action != NULL) {
+        if (hal_servo_cancel_all() != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to cancel servo motions before state/action switch");
+        }
+    }
+
     s_ctx.current_state = state_def;
     s_ctx.current_action = action_def;
     behavior_copy_string(s_ctx.current_state_id, sizeof(s_ctx.current_state_id), state_def->id);
     behavior_copy_string(s_ctx.current_action_id, sizeof(s_ctx.current_action_id),
                          action_def != NULL ? action_def->id : NULL);
     s_ctx.state_started_ms = now_ms;
+    s_ctx.action_started_ms = now_ms;
     s_ctx.next_motion_index = 0;
     s_ctx.next_action_motion_index = 0;
     s_ctx.next_expression_index = 0;
@@ -1643,16 +1693,30 @@ static void behavior_task(void *arg) {
 
             if (s_ctx.current_state != NULL) {
                 uint32_t elapsed_ms;
+                uint32_t action_elapsed_ms;
                 uint32_t done_at_ms;
 
                 behavior_dispatch_due_events_locked(now_ms, &display_request);
                 elapsed_ms = now_ms - s_ctx.state_started_ms;
+                action_elapsed_ms = behavior_action_elapsed_ms_locked(now_ms);
+
+                if (behavior_should_loop_action_locked() && s_ctx.current_action != NULL &&
+                    s_ctx.current_action->total_duration_ms > 0 && behavior_all_action_events_dispatched_locked() &&
+                    action_elapsed_ms >= s_ctx.current_action->total_duration_ms) {
+                    ESP_LOGI(TAG, "Looping action '%s' for state '%s'",
+                             s_ctx.current_action_id[0] != '\0' ? s_ctx.current_action_id : "<none>",
+                             s_ctx.current_state_id[0] != '\0' ? s_ctx.current_state_id : s_ctx.catalog.default_state);
+                    s_ctx.action_started_ms = now_ms;
+                    s_ctx.next_action_motion_index = 0;
+                    behavior_dispatch_due_events_locked(now_ms, &display_request);
+                    action_elapsed_ms = behavior_action_elapsed_ms_locked(now_ms);
+                }
 
                 if (s_ctx.current_state->loop) {
                     if (s_ctx.current_state->timeline_end_ms > 0 && behavior_all_state_events_dispatched_locked() &&
                         behavior_all_action_events_dispatched_locked() &&
                         elapsed_ms >= s_ctx.current_state->timeline_end_ms &&
-                        (s_ctx.current_action == NULL || elapsed_ms >= s_ctx.current_action->total_duration_ms)) {
+                        (s_ctx.current_action == NULL || action_elapsed_ms >= s_ctx.current_action->total_duration_ms)) {
                         s_ctx.state_started_ms = now_ms;
                         s_ctx.next_motion_index = 0;
                         s_ctx.next_expression_index = 0;
@@ -1923,10 +1987,28 @@ bool behavior_state_is_action_active(void) {
     }
 
     if (s_ctx.current_action != NULL && s_ctx.current_action->total_duration_ms > 0) {
-        elapsed_ms = behavior_now_ms() - s_ctx.state_started_ms;
+        elapsed_ms = behavior_now_ms() - s_ctx.action_started_ms;
         active = elapsed_ms < s_ctx.current_action->total_duration_ms;
     }
 
     behavior_unlock();
     return active;
+}
+
+esp_err_t behavior_state_interrupt_action(const char *source) {
+    esp_err_t ret = ESP_OK;
+
+    if (behavior_state_init() != ESP_OK) {
+        return ESP_FAIL;
+    }
+    if (!behavior_lock()) {
+        return ESP_FAIL;
+    }
+
+    if (!behavior_stop_current_action_locked(source)) {
+        ret = ESP_ERR_NOT_FOUND;
+    }
+
+    behavior_unlock();
+    return ret;
 }

--- a/firmware/s3/components/services/control_ingress/src/control_ingress.c
+++ b/firmware/s3/components/services/control_ingress/src/control_ingress.c
@@ -311,6 +311,8 @@ esp_err_t control_ingress_init(void) {
 }
 
 esp_err_t control_ingress_submit_servo(const control_servo_request_t *req) {
+    esp_err_t interrupt_ret;
+
     if (req == NULL) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -325,6 +327,11 @@ esp_err_t control_ingress_submit_servo(const control_servo_request_t *req) {
     }
     if (req->has_y && (req->y_deg < 0 || req->y_deg > 180)) {
         return ESP_ERR_INVALID_ARG;
+    }
+
+    interrupt_ret = behavior_state_interrupt_action("control_ingress_servo");
+    if (interrupt_ret != ESP_OK && interrupt_ret != ESP_ERR_NOT_FOUND) {
+        ESP_LOGW(TAG, "Failed to interrupt action loop before servo control: %s", esp_err_to_name(interrupt_ret));
     }
 
     if (req->has_x && req->has_y) {


### PR DESCRIPTION
## Summary
- interrupt looping action playback when manual servo control arrives from control ingress or BLE
- cancel queued and in-flight HAL servo motions during action interruption and state/action handoff
- refresh servo and behavior docs to match the current startup pose, Y-axis limits, and cancel semantics

## Testing
- cmd /c call C:\Espressif\frameworks\esp-idf-v5.2.1\export.bat && idf.py -B build-Z2 build
- flashed to Z and Z2 via the lane flashing flow using the built build-Z2 image