### PR TITLE
[codex] add project architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+---
+
+## Project Overview
+
+WatcheRobot is an ESP32-S3 based AI assistant robot firmware with voice interaction, servo control, LVGL display, BLE, and camera streaming. Built on SenseCAP Watcher hardware.
+
+---
+
+## Build Commands
+
+> **⚠️ IMPORTANT: Codex should NOT attempt to run `idf.py build` commands.**
+> The current shell environment (Git Bash/MSys) is not compatible with ESP-IDF.
+> Build commands are for reference only — user must run builds manually in a supported terminal.
+
+```bash
+# Activate ESP-IDF environment first (Windows PowerShell)
+C:\Espressif\frameworks\esp-idf-v5.2.1\export.ps1
+
+# Navigate to firmware directory
+cd firmware/s3
+
+# Set target and build
+idf.py set-target esp32s3
+idf.py build
+
+# Flash and monitor
+idf.py -p COM3 flash monitor    # Windows
+idf.py -p /dev/ttyUSB0 flash monitor  # Linux
+
+# Configuration menu
+idf.py menuconfig
+# Navigate: Watcher Configuration → WiFi / Server / HAL settings
+
+# Clean build
+idf.py fullclean && idf.py build
+```
+
+---
+
+## Architecture: Four-Layer Component Model
+
+```
+firmware/s3/components/
+├── drivers/        # Layer 1 — BSP (sensecap-watcher SDK wrapper)
+├── hal/            # Layer 2 — Hardware Abstraction (audio, display, servo, camera, button)
+├── protocols/      # Layer 3 — Communication (ws_client, discovery, ble_service)
+├── services/       # Layer 4 — Business Logic (voice, anim, camera, ota)
+└── utils/          # Cross-layer utilities (wifi_manager, boot_anim)
+```
+
+### Layer Dependency Rules (Strictly Enforced)
+
+| Layer | Can depend on | Cannot depend on |
+|-------|--------------|-----------------|
+| `services/` | `hal/`, `protocols/`, `utils/` | other `services/` |
+| `protocols/` | `hal/`, `utils/` | `services/` |
+| `hal/` | `drivers/`, `utils/` | `protocols/`, `services/` |
+| `drivers/` | ESP-IDF only | any custom component |
+| `utils/` | ESP-IDF only | any custom component |
+
+---
+
+## Component Structure Requirements
+
+Every component must include:
+
+```
+my_component/
+├── CMakeLists.txt         # Required
+├── idf_component.yml      # Required — version, description, license
+├── Kconfig                # Required — all configurable params
+├── README.md              # Required — purpose, API summary
+├── CHANGELOG.md           # Required — version history
+├── include/               # Public headers with Doxygen
+└── src/                   # Implementation
+```
+
+---
+
+## Code Style
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|------|-----------|---------|
+| Functions | `{component}_{verb}_{noun}` | `hal_servo_set_angle()` |
+| Types | `{component}_{name}_t` | `servo_axis_t` |
+| Constants | `UPPER_SNAKE_CASE` | `SERVO_Y_MIN_DEG` |
+| Kconfig | `WATCHER_{COMPONENT}_{PARAM}` | `WATCHER_SERVO_X_GPIO` |
+
+### Formatting
+
+```bash
+# Format with clang-format
+clang-format -i firmware/s3/components/hal/hal_servo/src/hal_servo.c
+
+# Check formatting
+clang-format --dry-run --Werror firmware/s3/components/**/*.c
+```
+
+### Error Handling
+
+- All functions return `esp_err_t`
+- Use `ESP_ERROR_CHECK()` for critical paths
+- Never silently ignore errors
+
+---
+
+## Key Hardware Configuration
+
+| Component | GPIO | Notes |
+|-----------|------|-------|
+| Servo X-axis | 19 | LEDC PWM, 0–180° |
+| Servo Y-axis | 20 | LEDC PWM, 90–150° (mechanical limit) |
+| Audio | I2S | Managed by sensecap-watcher BSP |
+| Display | QSPI | SPD2010 412×412 LCD |
+| Camera | SPI/UART | Himax HX6538 via SSCMA protocol |
+
+---
+
+## WebSocket Protocol
+
+### Downlink (Server → Device)
+
+| `type` | Description |
+|--------|-------------|
+| `servo` | Move servo: `{"id":"X","angle":90,"time":500}` |
+| `display` | Update display: `{"text":"...","emoji":"speaking"}` |
+| `camera_start` / `camera_stop` | Video stream control |
+| `fw_ota_notify` | OTA trigger with URL + SHA256 |
+
+### Uplink (Device → Server)
+
+| `type` | Description |
+|--------|-------------|
+| `audio_end` | Recording complete |
+| `status` | State report |
+| `device_info` | On-connect: firmware version, hardware ID |
+
+Binary frames: PCM audio (16kHz uplink, 24kHz downlink), WVID video format.
+
+---
+
+## Commit Message Format
+
+Conventional Commits with component scope:
+
+```
+<type>(<scope>): <description>
+
+# Examples:
+feat(hal_servo): add synchronized dual-axis smooth move
+fix(anim_service): release PSRAM buffer before loading new animation
+refactor(ws_client): extract protocol parsing into ws_protocol.c
+docs(hal_camera): add Doxygen for capture_once API
+```
+
+Types: `feat` `fix` `refactor` `docs` `test` `chore` `perf` `ci`
+
+---
+
+## Memory Layout
+
+- Flash: 16MB total
+- Firmware partitions: 2× 5MB (ota_0, ota_1)
+- SPIFFS storage: 5.5MB (animation assets + OTA buffer)
+- PSRAM: 8MB (LVGL frame buffers, decoded PNGs)
+
+---
+
+## Related Documentation
+
+- [docs/architecture.md](docs/architecture.md) — Full system design
+- [docs/getting-started.md](docs/getting-started.md) — Setup guide
+- [docs/hardware/gpio-mapping.md](docs/hardware/gpio-mapping.md) — Pin reference
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development guidelines
+
+---
+
+## Dependency Version Constraints
+
+> **DO NOT upgrade these components without explicit user approval.**
+
+| Component | Locked Version | Reason |
+|-----------|---------------|--------|
+| `espressif/button` | `~3.2.3` | sensecap-watcher SDK uses v3 API (`BUTTON_TYPE_CUSTOM`) |
+| `espressif/esp_lvgl_port` | `~1.4.0` | v2.x requires button v4.x |
+| `lvgl/lvgl` | `~8.4.0` | Compatible with esp_lvgl_port v1.x |
+
+The sensecap-watcher SDK is a third-party component that should not be modified. Upgrading button or esp_lvgl_port would require forking and patching the SDK.

--- a/docs/project-architecture-diagram.md
+++ b/docs/project-architecture-diagram.md
@@ -1,0 +1,398 @@
+# WatcheRobot 项目架构图
+
+本文档根据 `firmware/s3` 当前工程结构生成，展示 ESP32-S3 固件的分层组件、外部服务、硬件外设和主要数据链路。
+
+## 总体分层架构
+
+```mermaid
+flowchart TB
+    subgraph Cloud["云端 / 局域网服务"]
+        Server["watcher-server<br/>Python WebSocket 服务"]
+        ASR["ASR<br/>语音识别"]
+        Agent["LLM / Agent<br/>意图处理"]
+        TTS["TTS<br/>语音合成"]
+        FwServer["HTTP 固件 / 资源服务器"]
+        Server --> ASR --> Agent --> TTS --> Server
+    end
+
+    subgraph Device["ESP32-S3 固件 firmware/s3"]
+        Main["main/app_main.c<br/>系统启动 / 组件初始化 / 任务编排"]
+
+        subgraph Services["Layer 4: services 业务服务层"]
+            Voice["voice_service<br/>唤醒 / 录音 / TTS 播放生命周期"]
+            Anim["anim_service<br/>表情动画 / LVGL 播放"]
+            Behavior["behavior_state_service<br/>行为状态管理"]
+            Control["control_ingress<br/>控制入口聚合"]
+            CameraSvc["camera_service<br/>视频流控制"]
+            OTA["ota_service<br/>固件 OTA"]
+            SFX["sfx_service<br/>本地音效播放"]
+            McuMotion["mcu_motion_service<br/>运动控制"]
+            McuLed["mcu_led_service<br/>灯效控制"]
+            McuSensor["mcu_sensor_service<br/>传感器读取"]
+        end
+
+        subgraph Protocols["Layer 3: protocols 通信协议层"]
+            WS["ws_client<br/>WebSocket JSON / 二进制音视频"]
+            Discovery["discovery<br/>UDP 服务发现"]
+            BLE["ble_service<br/>BLE 控制 / WiFi 配网"]
+            McuLink["mcu_link<br/>UART 帧协议 / CRC / COBS"]
+        end
+
+        subgraph HAL["Layer 2: hal 硬件抽象层"]
+            Audio["hal_audio<br/>I2S 麦克风 / 扬声器 / PCM"]
+            Button["hal_button<br/>按键输入"]
+            Display["hal_display<br/>QSPI LCD / LVGL Port"]
+            Servo["hal_servo<br/>GPIO 19/20 LEDC PWM 舵机"]
+            CameraHal["hal_camera<br/>Himax 图像帧接口"]
+        end
+
+        subgraph Drivers["Layer 1: drivers / vendor 底层驱动与第三方组件"]
+            BSP["bsp_watcher<br/>板级封装"]
+            SenseCAP["sensecap-watcher SDK"]
+            SSCMA["sscma_client"]
+            LvglPort["esp_lvgl_port"]
+            IOExpander["esp_io_expander_pca95xx_16bit"]
+        end
+
+        subgraph Utils["utils 工具层"]
+            WiFi["wifi_manager<br/>WiFi 连接管理"]
+            BootAnim["boot_anim<br/>启动动画"]
+        end
+
+        Main --> Voice
+        Main --> Anim
+        Main --> Behavior
+        Main --> Control
+        Main --> CameraSvc
+        Main --> OTA
+        Main --> SFX
+        Main --> WS
+        Main --> Discovery
+        Main --> BLE
+        Main --> WiFi
+        Main --> BootAnim
+
+        Voice --> Audio
+        Voice --> Button
+        Voice --> WS
+        SFX --> Audio
+        Anim --> Display
+        Behavior --> Anim
+        Behavior --> Servo
+        Control --> Behavior
+        Control --> Servo
+        CameraSvc --> CameraHal
+        CameraSvc --> WS
+        OTA --> FwServer
+
+        WS --> Control
+        WS --> CameraSvc
+        WS --> OTA
+        Discovery --> WiFi
+        BLE --> WiFi
+        BLE --> Control
+        BLE --> Servo
+        McuMotion --> McuLink
+        McuLed --> McuLink
+        McuSensor --> McuLink
+
+        Audio --> SenseCAP
+        Button --> SenseCAP
+        Display --> SenseCAP
+        Display --> LvglPort
+        Servo --> McuMotion
+        CameraHal --> SenseCAP
+        CameraHal --> SSCMA
+        BSP --> SenseCAP
+        SenseCAP --> LvglPort
+        SenseCAP --> IOExpander
+        SenseCAP --> SSCMA
+    end
+
+    subgraph Hardware["硬件外设"]
+        Mic["I2S 麦克风"]
+        Speaker["I2S 扬声器"]
+        LCD["SPD2010<br/>412x412 QSPI LCD"]
+        Servos["双轴舵机<br/>GPIO 19 / GPIO 20"]
+        Himax["Himax HX6538 摄像头"]
+        ExtMCU["可选 MCU 外设<br/>运动 / LED / 传感器"]
+        Flash["16MB Flash<br/>OTA 分区 / SPIFFS"]
+        PSRAM["8MB PSRAM<br/>LVGL / 动画缓存"]
+        SD["SD 卡<br/>动画资源"]
+    end
+
+    WS <-->|"WiFi WebSocket<br/>JSON 控制 + 音频 + WVID 视频"| Server
+    Discovery <-->|"UDP 服务发现"| Server
+    BLE <-->|"BLE GATT / WiFi Provisioning"| Phone["手机 / BLE 客户端"]
+    OTA -->|"HTTP 下载"| FwServer
+
+    Audio <--> Mic
+    Audio <--> Speaker
+    Display --> LCD
+    Servo --> Servos
+    CameraHal <--> Himax
+    McuLink <--> ExtMCU
+    OTA --> Flash
+    Anim --> PSRAM
+    Anim --> SD
+```
+
+## 核心业务链路
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as 用户
+    participant Wake as 按键 / 唤醒词
+    participant Voice as voice_service
+    participant Audio as hal_audio
+    participant WS as ws_client
+    participant Server as watcher-server
+    participant Behavior as behavior_state_service
+    participant Anim as anim_service
+    participant Servo as hal_servo
+    participant Display as hal_display
+    participant Camera as camera_service
+    participant OTA as ota_service
+
+    rect rgb(236, 248, 255)
+        note over User,Server: 语音上行链路：采集与上传
+        User->>Wake: 唤醒词或按键触发
+        Wake->>Voice: 开始语音交互
+        Voice->>Audio: 采集麦克风音频
+        Audio-->>Voice: PCM 音频块
+        Voice->>WS: 上传音频二进制帧
+        Voice->>WS: 发送 audio_end
+        WS->>Server: WebSocket 上行
+    end
+
+    rect rgb(247, 244, 255)
+        note over Server,User: 服务器下行链路：响应与播放
+        Server-->>WS: 下发表情 / 舵机 / 行为 JSON
+        Server-->>WS: 下发 TTS 音频帧
+        WS->>Behavior: 分发行为状态
+        Behavior->>Anim: 切换表情动画
+        Anim->>Display: LVGL 渲染到 LCD
+        Behavior->>Servo: 控制双轴舵机
+        WS->>Audio: 播放 TTS 音频
+        Audio-->>User: 扬声器播放回复
+    end
+
+    rect rgb(245, 255, 244)
+        note over Server,Camera: 视频链路
+        Server-->>WS: camera_start / camera_stop
+        WS->>Camera: 更新视频流状态
+        Camera->>WS: WVID JPEG 二进制帧
+        WS->>Server: 上传视频流
+    end
+
+    rect rgb(255, 249, 235)
+        note over Server,OTA: OTA 链路
+        Server-->>WS: fw_ota_notify
+        WS->>OTA: 启动 OTA
+        OTA->>Server: HTTP 下载固件
+        OTA->>OTA: 校验 SHA256 并写入 OTA 分区
+    end
+```
+
+## 音频链路层
+
+```mermaid
+flowchart LR
+    subgraph Wakeup["唤醒方式"]
+        UserAction["用户触发"]
+        KeywordWake["关键词唤醒<br/>检测到唤醒词"]
+        ButtonWake["按键唤醒"]
+        ShortPress["短按<br/>5 秒内"]
+        LongPress["长按<br/>10 秒以上"]
+        StartVoice["进入语音采集"]
+        PowerOff["触发关机"]
+
+        UserAction --> KeywordWake
+        UserAction --> ButtonWake
+        KeywordWake --> StartVoice
+        ButtonWake --> ShortPress
+        ButtonWake --> LongPress
+        ShortPress --> StartVoice
+        LongPress --> PowerOff
+    end
+
+    subgraph Uplink["上行链路：语音采集与上传"]
+        UserVoice["用户语音"]
+        MicIn["I2S 麦克风"]
+        HalAudioRx["hal_audio<br/>音频采集 / 采样率处理"]
+        VoiceCapture["voice_service<br/>录音 / 分片"]
+        WsUplink["ws_client<br/>音频二进制帧 + audio_end"]
+        WiFiUp["WiFi"]
+        ServerRx["服务器<br/>接收音频"]
+        ASR["ASR<br/>语音识别"]
+
+        UserVoice --> MicIn
+        MicIn --> HalAudioRx
+        HalAudioRx --> VoiceCapture
+        VoiceCapture --> WsUplink
+        WsUplink --> WiFiUp
+        WiFiUp --> ServerRx
+        ServerRx --> ASR
+    end
+
+    subgraph Downlink["下行链路：服务器响应及播放"]
+        Agent2["LLM / Agent<br/>生成回复"]
+        TTS2["TTS<br/>回复音频生成"]
+        ServerTx["服务器<br/>下发音频流"]
+        WiFiDown["WiFi"]
+        WsDownlink["ws_client<br/>接收 TTS 音频帧"]
+        Playback["voice_service / audio worker<br/>缓冲播放控制"]
+        HalAudioTx["hal_audio<br/>解码 / 扬声器输出"]
+        SpeakerOut["I2S 扬声器"]
+        UserHear["用户听到回复"]
+
+        Agent2 --> TTS2
+        TTS2 --> ServerTx
+        ServerTx --> WiFiDown
+        WiFiDown --> WsDownlink
+        WsDownlink --> Playback
+        Playback --> HalAudioTx
+        HalAudioTx --> SpeakerOut
+        SpeakerOut --> UserHear
+    end
+
+    StartVoice --> VoiceCapture
+    ASR --> Agent2
+```
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as 用户
+    participant Wake as 唤醒模块
+    participant Mic as I2S 麦克风
+    participant Audio as hal_audio
+    participant Voice as voice_service
+    participant WS as ws_client
+    participant Server as 服务器
+    participant ASR
+    participant Agent as LLM / Agent
+    participant TTS
+    participant Speaker as I2S 扬声器
+
+    alt 关键词唤醒
+        User->>Wake: 说出唤醒词
+        Wake->>Voice: 检测到关键词，进入语音采集
+    else 按键唤醒：短按 5 秒内
+        User->>Wake: 按键时间 <= 5 秒
+        Wake->>Voice: 进入语音采集
+    else 按键长按：10 秒以上
+        User->>Wake: 按键时间 >= 10 秒
+        Wake-->>User: 触发关机
+    end
+
+    rect rgb(236, 248, 255)
+        note over User,Server: 上行链路：语音采集与上传
+        User->>Mic: 唤醒后说话
+        Mic->>Audio: I2S 音频采样
+        Audio->>Voice: 音频数据块
+        Voice->>WS: 上传音频二进制帧
+        Voice->>WS: 发送 audio_end
+        WS->>Server: WebSocket 上行
+        Server->>ASR: 语音识别
+    end
+
+    rect rgb(247, 244, 255)
+        note over Server,Speaker: 下行链路：服务器响应及播放
+        ASR->>Agent: 识别文本
+        Agent->>TTS: 回复文本
+        TTS->>Server: 生成回复音频
+        Server->>WS: WebSocket 下发 TTS 音频帧
+        WS->>Voice: 播放事件 / 音频数据
+        Voice->>Audio: 缓冲播放
+        Audio->>Speaker: I2S 输出
+        Speaker-->>User: 播放服务器回复
+    end
+```
+
+## 音频编解码器与音频流格式
+
+```mermaid
+flowchart TB
+    subgraph Control["控制信号通信"]
+        ESP32Ctrl["ESP32-S3"]
+        I2C["I2C0<br/>SDA GPIO47<br/>SCL GPIO48<br/>400 kHz"]
+        ES8311Ctrl["ES8311 DAC<br/>I2C 地址 0x30"]
+        ES7243Ctrl["ES7243 / ES7243E ADC<br/>I2C 地址 0x13 / 0x14"]
+        PA["功放电源控制<br/>IO Expander Pin 12"]
+
+        ESP32Ctrl --> I2C
+        I2C --> ES8311Ctrl
+        I2C --> ES7243Ctrl
+        ESP32Ctrl --> PA
+    end
+
+    subgraph Data["音频数据通信"]
+        ESP32Data["ESP32-S3 I2S0<br/>I2S Master"]
+        I2SBus["I2S 标准模式<br/>MCLK GPIO10<br/>BCLK/SCLK GPIO11<br/>LRCK/WS GPIO12<br/>DIN GPIO15<br/>DOUT GPIO16"]
+        ADC["ES7243 / ES7243E<br/>麦克风 ADC 输入"]
+        DAC["ES8311<br/>扬声器 DAC 输出"]
+        MicCodec["I2S 麦克风"]
+        SpeakerCodec["扬声器 / 功放"]
+
+        MicCodec --> ADC
+        ADC -->|"上行 PCM"| I2SBus
+        I2SBus --> ESP32Data
+        ESP32Data --> I2SBus
+        I2SBus -->|"下行 PCM"| DAC
+        DAC --> SpeakerCodec
+    end
+
+    subgraph Format["音频流格式"]
+        RecordFmt["录音 / 上行<br/>PCM passthrough<br/>16 kHz<br/>16-bit signed<br/>Mono<br/>60 ms frame = 960 samples = 1920 bytes"]
+        PlayFmt["播放 / 下行<br/>TTS PCM playback<br/>24 kHz<br/>16-bit<br/>Mono"]
+    end
+
+    ESP32Data --> RecordFmt
+    ESP32Data --> PlayFmt
+```
+
+| 项目 | 当前工程配置 |
+|------|--------------|
+| 麦克风输入编解码器 | `ES7243` ADC；若未检测到 `0x13`，回退使用 `ES7243E`，地址 `0x14` |
+| 扬声器输出编解码器 | `ES8311` DAC，地址 `0x30` |
+| 控制信号通信 | I2C0，SDA `GPIO47`，SCL `GPIO48`，400 kHz |
+| 音频数据通信 | I2S0，ESP32-S3 为 Master |
+| I2S 管脚 | MCLK `GPIO10`，BCLK/SCLK `GPIO11`，LRCK/WS `GPIO12`，DIN `GPIO15`，DOUT `GPIO16` |
+| I2S 数据格式 | Standard I2S，mono，16-bit，MSB first，little-endian |
+| 上行音频流 | PCM passthrough，无压缩；16 kHz，16-bit signed，mono |
+| 上行帧大小 | 60 ms，960 samples，1920 bytes，约 256 kbps |
+| 下行音频流 | TTS PCM playback；24 kHz，16-bit，mono |
+| 功放控制 | codec PA power 通过 IO expander pin 12 控制 |
+
+## 工程目录视图
+
+```mermaid
+flowchart LR
+    Repo["WatcheRobot-Firmware"]
+    Repo --> Firmware["firmware/s3<br/>ESP32-S3 固件主工程"]
+    Repo --> Docs["docs<br/>架构 / 入门 / 开发文档"]
+    Repo --> HardwareDocs["hardware<br/>硬件设计资料"]
+    Repo --> Tools["tools<br/>刷机与发布辅助工具"]
+    Repo --> CI[".github<br/>CI 工作流"]
+
+    Firmware --> MainDir["main<br/>app_main / 内存监控 / 压测模式"]
+    Firmware --> Components["components<br/>分层组件"]
+    Firmware --> Partitions["partitions.csv<br/>Flash 分区"]
+    Firmware --> SDKConfig["sdkconfig.defaults<br/>默认配置"]
+
+    Components --> DriverDir["drivers<br/>bsp_watcher"]
+    Components --> HALDir["hal<br/>audio / button / camera / display / servo"]
+    Components --> ProtocolDir["protocols<br/>ws_client / discovery / ble_service / mcu_link"]
+    Components --> ServiceDir["services<br/>voice / anim / behavior / camera / ota / sfx / mcu_*"]
+    Components --> UtilsDir["utils<br/>wifi_manager / boot_anim"]
+    Components --> VendorDir["vendor<br/>sensecap-watcher / sscma_client / lvgl port"]
+```
+
+## 说明
+
+- 项目目标架构为四层组件模型：`services` -> `protocols` / `hal` / `utils` -> `drivers` / ESP-IDF。
+- 图中保留了当前工程里的实际组件，例如 `behavior_state_service`、`control_ingress`、`mcu_link`、`sfx_service` 等。
+- 当前工程存在少量过渡期依赖，例如 `hal_servo` 私有依赖 `mcu_motion_service`、部分协议组件直接路由到服务组件；图中按当前 CMake 依赖关系如实体现。
+- 本文档只生成架构图，不涉及 `idf.py build`。

--- a/firmware/s3/components/services/voice_service/Kconfig
+++ b/firmware/s3/components/services/voice_service/Kconfig
@@ -1,0 +1,73 @@
+menu "Watcher Voice Service"
+
+    config WATCHER_ENABLE_WAKE_WORD
+        bool "Enable local wake word detection"
+        default y
+        depends on IDF_TARGET_ESP32S3 && SPIRAM && USE_WAKENET
+        help
+            Enable offline wake word detection using Espressif ESP-SR AFE and
+            the selected WakeNet model. Audio stays at 16 kHz while idle so the
+            detector can run continuously.
+
+    if WATCHER_ENABLE_WAKE_WORD
+
+    config WATCHER_WAKE_WORD_HIGH_PERF_MODE
+        bool "Use high performance AFE mode"
+        default n
+        help
+            Use SR_MODE_HIGH_PERF instead of SR_MODE_LOW_COST. This can improve
+            detection robustness but increases CPU and memory pressure.
+
+    config WATCHER_WAKE_WORD_SENSITIVE_MODE
+        bool "Use sensitive WakeNet threshold"
+        default n
+        help
+            Use DET_MODE_95 instead of DET_MODE_90. This is more sensitive and
+            may increase false wakeups.
+
+    config WATCHER_WAKE_WORD_TASK_STACK_SIZE
+        int "Wake word detection task stack size"
+        range 3072 8192
+        default 4096
+
+    config WATCHER_WAKE_WORD_TASK_PRIORITY
+        int "Wake word detection task priority"
+        range 3 10
+        default 6
+
+    config WATCHER_WAKE_WORD_AFE_CORE
+        int "AFE preferred core"
+        range 0 1
+        default 1
+
+    config WATCHER_WAKE_WORD_AFE_PRIORITY
+        int "AFE preferred priority"
+        range 1 10
+        default 3
+
+    config WATCHER_WAKE_WORD_AFE_RINGBUF_SIZE
+        int "AFE ring buffer size"
+        range 10 100
+        default 50
+
+    config WATCHER_VAD_SILENCE_TIMEOUT_MS
+        int "VAD silence timeout after wake word (ms)"
+        range 0 10000
+        default 1200
+        help
+            Stop wake-word-triggered recording after this much silence. Set to
+            0 to disable automatic silence stop.
+
+    config WATCHER_VAD_RMS_THRESHOLD
+        int "VAD RMS threshold"
+        range 50 5000
+        default 450
+
+    config WATCHER_VAD_MIN_SPEECH_MS
+        int "VAD minimum speech duration (ms)"
+        range 0 5000
+        default 600
+
+    endif
+
+endmenu


### PR DESCRIPTION
## Summary

- Add an `AGENTS.md` guide for repository architecture, build constraints, code style, hardware mapping, protocol notes, and dependency locks.
- Add `docs/project-architecture-diagram.md` with the project architecture documentation and diagram-oriented overview.
- Add the `voice_service` Kconfig stub required by the documented component structure.

## Related Issues

N/A

## Type of Change

- [ ] `feat` - new feature
- [ ] `fix` - bug fix
- [ ] `refactor` - code restructure, no behavior change
- [x] `docs` - documentation only
- [ ] `test` - tests only
- [ ] `ci` - CI/CD changes
- [ ] `chore` - maintenance, dependency updates

## Component(s) Affected

- `docs`
- `voice_service`

## Checklist

- [ ] Code compiles without warnings (`idf.py build`)
- [ ] `clang-format` passes (`pre-commit run --all-files`)
- [ ] New component includes `idf_component.yml`, `Kconfig`, `README.md`, `CHANGELOG.md`
- [ ] All public APIs have Doxygen comments in `include/`
- [x] New configurable values exposed via Kconfig (no hardcoded values)
- [ ] `test_apps/` updated with Unity tests for new logic
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Layer dependency rules respected (see `docs/architecture.md`)

## Test Plan

- [x] Documentation-only change reviewed locally.
- [ ] ESP-IDF build not run; current Codex shell is not compatible with ESP-IDF per repository instructions.