### PR TITLE
[codex] update button recording and shutdown controls

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -72,13 +72,15 @@ ctest --test-dir build -V
 
 | # | Test | Expected | Status |
 |---|------|----------|--------|
-| 2.1 | Button long press → recording | Display "Listening..." | ⬜ |
+| 2.1 | Button short press → start recording | Display "Listening..." | ⬜ |
 | 2.2 | Send Raw PCM 16kHz | Server receives audio | ⬜ |
-| 2.3 | Button release → audio_end | Server acknowledges | ⬜ |
-| 2.4 | Receive asr_result | Display recognized text | ⬜ |
-| 2.5 | Receive bot_reply | Display AI response | ⬜ |
-| 2.6 | Receive TTS audio | Play Raw PCM 24kHz | ⬜ |
-| 2.7 | tts_end received | Resume wake word | ⬜ |
+| 2.3 | Button short press while recording → audio_end | Server acknowledges | ⬜ |
+| 2.4 | Button 4-click | Device reboots | ⬜ |
+| 2.5 | Button 6s hold | STM32 5V off request sent, then ESP32 shutdown GPIO asserted | ⬜ |
+| 2.6 | Receive asr_result | Display recognized text | ⬜ |
+| 2.7 | Receive bot_reply | Display AI response | ⬜ |
+| 2.8 | Receive TTS audio | Play Raw PCM 24kHz | ⬜ |
+| 2.9 | tts_end received | Resume wake word | ⬜ |
 
 ### 4.3 Wake Word Test
 
@@ -155,7 +157,9 @@ Before each release:
 - [ ] All unit tests pass
 - [ ] Integration tests pass
 - [ ] Wake word detection works
-- [ ] Button recording works
+- [ ] Button short press start/stop recording works
+- [ ] Button 4-click reboot works
+- [ ] Button 6s hold shutdown path works
 - [ ] TTS playback works
 - [ ] Servo control works
 - [ ] Animation smooth at 30fps

--- a/docs/hardware/gpio-mapping.md
+++ b/docs/hardware/gpio-mapping.md
@@ -50,7 +50,7 @@ Communication with the Himax vision AI chip uses the SSCMA protocol over SPI/UAR
 
 | GPIO | Function | Notes |
 |------|----------|-------|
-| See sensecap-watcher SDK | Physical button | Long press = start recording, 5-click = reboot |
+| See sensecap-watcher SDK | Physical button | Short press = start/stop recording, 4-click = reboot, 6s hold = shutdown |
 
 ---
 

--- a/firmware/s3/components/sensecap-watcher/include/sensecap-watcher.h
+++ b/firmware/s3/components/sensecap-watcher/include/sensecap-watcher.h
@@ -275,7 +275,7 @@ esp_err_t bsp_i2c_detect(i2c_port_t i2c_num);
 
 void bsp_system_deep_sleep(uint32_t time_in_sec);
 void bsp_system_reboot(void);
-void bsp_system_shutdown(void);
+esp_err_t bsp_system_shutdown(void);
 bool bsp_system_is_charging(void);
 bool bsp_system_is_standby(void);
 bool bsp_battery_is_present(void);
@@ -289,6 +289,7 @@ esp_err_t bsp_knob_btn_init(void *param);
 uint8_t bsp_knob_btn_get_key_value(void *param);
 esp_err_t bsp_knob_btn_deinit(void *param);
 void bsp_set_btn_long_press_cb(void (*cb)(void));
+void bsp_set_btn_long_press_ms_cb(uint16_t press_time_ms, void (*cb)(void));
 void bsp_set_btn_long_release_cb(void (*cb)(void));
 
 /**

--- a/firmware/s3/components/sensecap-watcher/sensecap-watcher.c
+++ b/firmware/s3/components/sensecap-watcher/sensecap-watcher.c
@@ -280,6 +280,10 @@ static void bsp_btn_cb(void *arg, void *arg2) {
 }
 
 void bsp_set_btn_long_press_cb(void (*cb)(void)) {
+    bsp_set_btn_long_press_ms_cb(0, cb);
+}
+
+void bsp_set_btn_long_press_ms_cb(uint16_t press_time_ms, void (*cb)(void)) {
     lv_indev_t *tp = NULL;
     while (1) {
         tp = lv_indev_get_next(tp);
@@ -293,7 +297,22 @@ void bsp_set_btn_long_press_cb(void (*cb)(void)) {
         return;
     }
 
-    lvgl_port_encoder_btn_register_event_cb(tp, BUTTON_LONG_PRESS_START, bsp_btn_cb, cb);
+    if (press_time_ms == 0) {
+        lvgl_port_encoder_btn_register_event_cb(tp, BUTTON_LONG_PRESS_START, bsp_btn_cb, cb);
+        return;
+    }
+
+    button_event_config_t event_cfg = {
+        .event = BUTTON_LONG_PRESS_START,
+        .event_data.long_press.press_time = press_time_ms,
+    };
+    esp_err_t ret = lvgl_port_encoder_btn_register_event_data_cb(tp, event_cfg, bsp_btn_cb, cb);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register %u ms long-press callback: %s", (unsigned)press_time_ms,
+                 esp_err_to_name(ret));
+    } else {
+        ESP_LOGI(TAG, "Registered %u ms long-press callback", (unsigned)press_time_ms);
+    }
 }
 
 void bsp_set_btn_long_release_cb(void (*cb)(void)) {
@@ -576,8 +595,14 @@ void bsp_system_reboot(void) {
     esp_restart();
 }
 
-void bsp_system_shutdown(void) {
-    bsp_exp_io_set_level(BSP_PWR_SYSTEM, 0);
+esp_err_t bsp_system_shutdown(void) {
+    esp_err_t ret = bsp_exp_io_set_level(BSP_PWR_SYSTEM, 0);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "System shutdown request failed: %s", esp_err_to_name(ret));
+    } else {
+        ESP_LOGW(TAG, "System shutdown requested: BSP_PWR_SYSTEM=0");
+    }
+    return ret;
 }
 
 bool bsp_system_is_charging(void) {
@@ -908,7 +933,7 @@ static lv_indev_t *bsp_knob_indev_init(lv_disp_t *disp) {
     };
     const static button_config_t btn_config = {
         .type = BUTTON_TYPE_CUSTOM,
-        .long_press_time = 500, /* Reduced from 2000ms to 500ms for faster voice trigger */
+        .long_press_time = 6000,
         .short_press_time = 200,
         .custom_button_config =
             {

--- a/firmware/s3/components/services/mcu_power_service/src/mcu_power_service.c
+++ b/firmware/s3/components/services/mcu_power_service/src/mcu_power_service.c
@@ -46,9 +46,14 @@ esp_err_t mcu_power_set_5v_enabled(bool enabled, mcu_power_source_t source, uint
         return ESP_ERR_INVALID_STATE;
     }
 
-    if (!mcu_link_bootstrap_is_ready()) {
-        ESP_LOGW(TAG, "MCU link not fully ready; rejecting power request");
+    if (!mcu_link_bootstrap_is_ready() && enabled) {
+        ESP_LOGW(TAG, "MCU link not fully ready; rejecting power-on request");
         return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!mcu_link_bootstrap_is_ready()) {
+        ESP_LOGW(TAG, "MCU link not fully ready; sending power-off request anyway (state=%d)",
+                 (int)mcu_link_bootstrap_get_state());
     }
 
     payload[0] = (uint8_t)source;

--- a/firmware/s3/components/services/voice_service/include/voice_service.h
+++ b/firmware/s3/components/services/voice_service/include/voice_service.h
@@ -13,8 +13,8 @@ typedef enum {
 /* Voice recorder events */
 typedef enum {
     VOICE_EVENT_NONE = 0,
-    VOICE_EVENT_BUTTON_PRESS,   /* Button pressed - start recording */
-    VOICE_EVENT_BUTTON_RELEASE, /* Button released - stop recording */
+    VOICE_EVENT_BUTTON_PRESS,   /* Short press toggle - start recording */
+    VOICE_EVENT_BUTTON_RELEASE, /* Short press toggle - stop recording */
     VOICE_EVENT_TIMEOUT,        /* Max recording time reached */
     VOICE_EVENT_WAKE_WORD,      /* Wake word detected - start recording */
 } voice_event_t;

--- a/firmware/s3/components/services/voice_service/src/voice_fsm.c
+++ b/firmware/s3/components/services/voice_service/src/voice_fsm.c
@@ -3,6 +3,7 @@
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_lvgl_port.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "hal_audio.h"
@@ -38,6 +39,8 @@ static void wake_word_cleanup(void);
 
 static voice_state_t g_state = VOICE_STATE_IDLE;
 static voice_stats_t g_stats = {0};
+static bool g_button_pressed = false;
+static int64_t g_button_press_start_ms = 0;
 
 /* Track how recording was triggered (for button behavior) */
 static bool g_recording_triggered_by_wake_word = false;
@@ -46,6 +49,8 @@ static bool g_recording_triggered_by_wake_word = false;
 #define PCM_FRAME_SIZE 1920
 
 static uint8_t g_pcm_buf[PCM_FRAME_SIZE];
+
+#define BUTTON_SHORT_PRESS_MAX_MS 3000
 
 #if CONFIG_WATCHER_LOG_HEAP_DIAGNOSTICS
 #define LOG_INTERNAL_HEAP_STATE(stage) log_internal_heap_state(stage)
@@ -343,6 +348,36 @@ static int stop_recording(void) {
     return 0;
 }
 
+static int64_t voice_now_ms(void) {
+    return esp_timer_get_time() / 1000;
+}
+
+static void handle_short_press_toggle(void) {
+    if (g_state == VOICE_STATE_IDLE) {
+        if (!ws_client_is_session_ready()) {
+            ESP_LOGW(TAG, "Short press ignored: ws session not ready (connected=%d)", ws_client_is_connected());
+            show_cloud_not_ready_state();
+            return;
+        }
+
+        ESP_LOGI(TAG, "Short press - starting recording");
+        g_recording_triggered_by_wake_word = false;
+        voice_recorder_process_event(VOICE_EVENT_BUTTON_PRESS);
+        if (g_state == VOICE_STATE_RECORDING) {
+            show_listening_ui();
+        } else {
+            show_cloud_not_ready_state();
+        }
+        return;
+    }
+
+    if (g_state == VOICE_STATE_RECORDING) {
+        ESP_LOGI(TAG, "Short press - stopping recording");
+        voice_recorder_process_event(VOICE_EVENT_BUTTON_RELEASE);
+        behavior_state_set_with_text("processing", "Processing...", 0);
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /* Public: Process event                                              */
 /* ------------------------------------------------------------------ */
@@ -499,35 +534,28 @@ int voice_recorder_tick(void) {
 static void button_callback(bool pressed) {
     /* This is called from task context (via hal_button_poll) */
     if (pressed) {
-        if (g_state == VOICE_STATE_IDLE) {
-            if (!ws_client_is_session_ready()) {
-                ESP_LOGW(TAG, "Button press ignored: ws session not ready (connected=%d)", ws_client_is_connected());
-                show_cloud_not_ready_state();
-                return;
-            }
-            /* Button triggers recording start */
-            ESP_LOGI(TAG, "Button PRESSED - starting recording");
-            g_recording_triggered_by_wake_word = false;
-            voice_recorder_process_event(VOICE_EVENT_BUTTON_PRESS);
-            if (g_state == VOICE_STATE_RECORDING) {
-                show_listening_ui();
-            } else {
-                show_cloud_not_ready_state();
-            }
-        } else if (g_state == VOICE_STATE_RECORDING) {
-            /* Already recording (wake word mode) - short press to stop */
-            ESP_LOGI(TAG, "Button PRESSED (short) - stopping recording (wake word mode)");
-            voice_recorder_process_event(VOICE_EVENT_BUTTON_RELEASE);
-            behavior_state_set_with_text("processing", "Processing...", 0);
-        }
+        g_button_pressed = true;
+        g_button_press_start_ms = voice_now_ms();
+        ESP_LOGI(TAG, "Button press started");
+        return;
+    }
+
+    int64_t released_ms = voice_now_ms();
+    if (g_button_press_start_ms <= 0) {
+        ESP_LOGI(TAG, "Ignoring release without tracked press");
+        g_button_pressed = false;
+        return;
+    }
+
+    int64_t held_ms = g_button_press_start_ms > 0 ? released_ms - g_button_press_start_ms : 0;
+
+    g_button_pressed = false;
+    g_button_press_start_ms = 0;
+
+    if (held_ms <= BUTTON_SHORT_PRESS_MAX_MS) {
+        handle_short_press_toggle();
     } else {
-        /* Button RELEASED - only stop if triggered by button (long press mode) */
-        if (g_state == VOICE_STATE_RECORDING && !g_recording_triggered_by_wake_word) {
-            ESP_LOGI(TAG, "Button RELEASED - stopping recording");
-            voice_recorder_process_event(VOICE_EVENT_BUTTON_RELEASE);
-            behavior_state_set_with_text("processing", "Processing...", 0);
-        }
-        /* If wake word triggered, ignore release (already stopped by short press) */
+        ESP_LOGI(TAG, "Ignoring medium press (%lld ms)", (long long)held_ms);
     }
 }
 
@@ -671,6 +699,8 @@ void voice_recorder_stop(void) {
     bool had_runtime = g_task_running || g_voice_task_handle != NULL;
 
     g_task_running = false;
+    g_button_pressed = false;
+    g_button_press_start_ms = 0;
 
     if (g_voice_task_handle != NULL && !voice_wait_for_task_exit(VOICE_TASK_EXIT_WAIT_MS)) {
         ESP_LOGW(TAG, "Voice recorder task did not exit within %u ms", (unsigned)VOICE_TASK_EXIT_WAIT_MS);

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -47,7 +47,9 @@
 #define MCU_OBS_TAG "MCU_OBS"
 
 /* Physical restart: click count to trigger reboot */
-#define RESTART_CLICK_COUNT 3
+#define RESTART_CLICK_COUNT 4
+#define BUTTON_SHUTDOWN_HOLD_MS 6000
+#define STM32_POWER_OFF_SETTLE_MS 300
 #define STARTUP_BEHAVIOR_POLL_MS 50
 #define STARTUP_BEHAVIOR_TIMEOUT_MS 10000
 #define CLOUD_DISCOVERY_TIMEOUT_MS 5000
@@ -143,6 +145,7 @@ static mcu_link_state_t s_last_mcu_obs_state = MCU_LINK_STATE_DOWN;
 static bool s_mcu_obs_stats_initialized = false;
 static mcu_link_stats_t s_last_mcu_obs_stats = {0};
 static int64_t s_last_mcu_obs_stats_log_us = 0;
+static volatile bool s_shutdown_in_progress = false;
 #if defined(WATCHER_STRESS_BUILD) || defined(CONFIG_WATCHER_STRESS_BUILD)
 static TaskHandle_t s_mcu_link_runtime_task = NULL;
 #endif
@@ -602,6 +605,37 @@ static void on_button_multi_click_restart(void) {
     esp_restart();
 }
 
+static void on_button_shutdown_hold(void) {
+    uint32_t power_seq = 0;
+    esp_err_t ret;
+
+    if (s_shutdown_in_progress) {
+        return;
+    }
+    s_shutdown_in_progress = true;
+
+    ESP_LOGW(TAG, "Button long press - shutting down");
+    behavior_state_set_with_text("error", "Shutting down...", 0);
+    voice_recorder_stop();
+
+    ret = mcu_power_set_5v_enabled(false, MCU_POWER_SOURCE_BEHAVIOR, &power_seq);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "STM32 5V power-off request failed: %s; keeping ESP32 powered", esp_err_to_name(ret));
+        s_shutdown_in_progress = false;
+        return;
+    }
+
+    ESP_LOGW(TAG, "STM32 5V power-off request queued seq=%lu; shutting down ESP32 after %u ms",
+             (unsigned long)power_seq, (unsigned)STM32_POWER_OFF_SETTLE_MS);
+    vTaskDelay(pdMS_TO_TICKS(STM32_POWER_OFF_SETTLE_MS));
+
+    ret = bsp_system_shutdown();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Shutdown GPIO request failed: %s", esp_err_to_name(ret));
+        s_shutdown_in_progress = false;
+    }
+}
+
 static void init_runtime_inputs_and_restart_path(void) {
     int input_ret;
     bool knob_ready;
@@ -616,6 +650,8 @@ static void init_runtime_inputs_and_restart_path(void) {
     }
 
     if (knob_ready) {
+        bsp_set_btn_long_press_ms_cb(BUTTON_SHUTDOWN_HOLD_MS, on_button_shutdown_hold);
+        ESP_LOGI(TAG, "Registered %d ms shutdown hold callback", BUTTON_SHUTDOWN_HOLD_MS);
         bsp_set_btn_multi_click_cb(RESTART_CLICK_COUNT, on_button_multi_click_restart);
         ESP_LOGI(TAG, "Registered %d-click restart callback", RESTART_CLICK_COUNT);
     } else {


### PR DESCRIPTION
## Summary

- Change the physical button UX to short-press start recording and short-press stop recording.
- Change restart from 3-click to 4-click to avoid conflict with rapid recording restart workflows.
- Move shutdown to the LVGL/iot_button path and register a 6s long-press callback, so shutdown is independent of cloud/WebSocket readiness.
- On shutdown, send the STM32 5V power-off request before asserting the ESP32 `BSP_PWR_SYSTEM` shutdown GPIO.
- Allow STM32 5V power-off requests to be queued even when the MCU link is not fully `READY`, while keeping power-on requests gated.
- Update button-related hardware and test documentation.

## Root Cause / Notes

The earlier long-press shutdown path was tied to `voice_task`, which only starts after cloud runtime/session readiness. During Wi-Fi reconnect or cloud-offline states, 4-click reboot still worked because it used the LVGL/iot_button input path, but shutdown could be unavailable. This PR moves shutdown onto the same reliable button path.

The 6s shutdown action confirms software-side power-off by observing the STM32 power request and `BSP_PWR_SYSTEM=0`. If ESP32 or STM32 remains externally powered through USB, ST-Link, serial adapters, or a direct 5V IN path, logs may continue after the shutdown request; that is a hardware power-path constraint rather than a missed software command.

## Validation

- `git diff --check`
- `idf.py build` from `firmware/s3`
- Bench-tested by user:
  - short press starts recording
  - short press stops recording
  - 4-click reboots
  - long-press threshold corrected and tested
  - shutdown sequence emits STM32 5V off request and asserts ESP32 shutdown GPIO