### PR TITLE
feat: 接入 ESP32 触摸表情响应

### DIFF
--- a/firmware/s3/components/services/mcu_sensor_service/include/mcu_sensor_service.h
+++ b/firmware/s3/components/services/mcu_sensor_service/include/mcu_sensor_service.h
@@ -11,7 +11,15 @@
 extern "C" {
 #endif
 
+typedef enum {
+    MCU_TOUCH_EVENT_PRESS = 1,
+    MCU_TOUCH_EVENT_RELEASE = 2,
+    MCU_TOUCH_EVENT_LONG_PRESS = 3,
+} mcu_touch_event_code_t;
+
 typedef struct {
+    uint8_t touch_id;
+    mcu_touch_event_code_t event_code;
     bool active;
     uint32_t timestamp_ms;
 } mcu_touch_state_t;

--- a/firmware/s3/components/services/mcu_sensor_service/src/mcu_sensor_service.c
+++ b/firmware/s3/components/services/mcu_sensor_service/src/mcu_sensor_service.c
@@ -197,7 +197,9 @@ esp_err_t mcu_sensor_service_handle_link_event(const mcu_link_event_t *event, bo
     switch (event->type) {
     case MCU_LINK_RX_EVENT_TOUCH_EVENT: {
         mcu_touch_state_t state = {
-            .active = event->frame.payload[1] != 2u,
+            .touch_id = event->frame.payload[0],
+            .event_code = (mcu_touch_event_code_t)event->frame.payload[1],
+            .active = event->frame.payload[1] != MCU_TOUCH_EVENT_RELEASE,
             .timestamp_ms = decode_u32_le(&event->frame.payload[2]),
         };
 
@@ -207,13 +209,12 @@ esp_err_t mcu_sensor_service_handle_link_event(const mcu_link_event_t *event, bo
         ret = mcu_sensor_service_apply_touch_impl(&state);
         if (ret == ESP_OK) {
             if (MCU_SENSOR_STRESS_LOGGING_DISABLED == 0) {
-                ESP_LOGI(TAG, "Touch EVENT id=%u code=%u ts=%lu active=%d", (unsigned)event->frame.payload[0],
-                         (unsigned)event->frame.payload[1], (unsigned long)state.timestamp_ms, state.active ? 1 : 0);
-                ESP_LOGI(OBS_TAG,
-                         "evt=touch_event msg_class=%u msg_id=%u touch_id=%u code=%u timestamp_ms=%lu active=%d",
-                         (unsigned)MCU_FRAME_CLASS_SENSOR, (unsigned)MCU_SENSOR_MSG_TOUCH_EVENT,
-                         (unsigned)event->frame.payload[0], (unsigned)event->frame.payload[1],
-                         (unsigned long)state.timestamp_ms, state.active ? 1 : 0);
+                ESP_LOGI(TAG, "Touch EVENT id=%u code=%u ts=%lu active=%d", (unsigned)state.touch_id,
+                         (unsigned)state.event_code, (unsigned long)state.timestamp_ms, state.active ? 1 : 0);
+                ESP_LOGI(
+                    OBS_TAG, "evt=touch_event msg_class=%u msg_id=%u touch_id=%u code=%u timestamp_ms=%lu active=%d",
+                    (unsigned)MCU_FRAME_CLASS_SENSOR, (unsigned)MCU_SENSOR_MSG_TOUCH_EVENT, (unsigned)state.touch_id,
+                    (unsigned)state.event_code, (unsigned long)state.timestamp_ms, state.active ? 1 : 0);
             }
         }
         return ret;

--- a/firmware/s3/components/services/mcu_sensor_service/test_support/host/CMakeLists.txt
+++ b/firmware/s3/components/services/mcu_sensor_service/test_support/host/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(mcu_sensor_service_host_tests C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+enable_testing()
+
+set(MCU_SENSOR_COMPONENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(MCU_LINK_COMPONENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../protocols/mcu_link")
+
+add_executable(mcu_sensor_service_host_tests
+    "${MCU_SENSOR_COMPONENT_DIR}/src/mcu_sensor_service.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/test_mcu_sensor_service.c"
+)
+
+target_include_directories(mcu_sensor_service_host_tests PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${MCU_SENSOR_COMPONENT_DIR}/include"
+    "${MCU_LINK_COMPONENT_DIR}/include"
+    "${MCU_LINK_COMPONENT_DIR}/test_support/host/include"
+)
+
+add_test(NAME mcu_sensor_service_host_tests COMMAND mcu_sensor_service_host_tests)

--- a/firmware/s3/components/services/mcu_sensor_service/test_support/host/include/esp_log.h
+++ b/firmware/s3/components/services/mcu_sensor_service/test_support/host/include/esp_log.h
@@ -1,0 +1,17 @@
+#ifndef ESP_LOG_H
+#define ESP_LOG_H
+
+#define ESP_LOGD(...)                                                                                                  \
+    do {                                                                                                               \
+    } while (0)
+#define ESP_LOGI(...)                                                                                                  \
+    do {                                                                                                               \
+    } while (0)
+#define ESP_LOGW(...)                                                                                                  \
+    do {                                                                                                               \
+    } while (0)
+#define ESP_LOGE(...)                                                                                                  \
+    do {                                                                                                               \
+    } while (0)
+
+#endif /* ESP_LOG_H */

--- a/firmware/s3/components/services/mcu_sensor_service/test_support/host/src/test_mcu_sensor_service.c
+++ b/firmware/s3/components/services/mcu_sensor_service/test_support/host/src/test_mcu_sensor_service.c
@@ -1,0 +1,76 @@
+#include "mcu_sensor_service.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
+static void write_u32_le(uint8_t *dst, uint32_t value) {
+    dst[0] = (uint8_t)(value & 0xFFu);
+    dst[1] = (uint8_t)((value >> 8u) & 0xFFu);
+    dst[2] = (uint8_t)((value >> 16u) & 0xFFu);
+    dst[3] = (uint8_t)((value >> 24u) & 0xFFu);
+}
+
+static mcu_link_event_t make_touch_event(uint8_t touch_id, mcu_touch_event_code_t code, uint32_t timestamp_ms) {
+    mcu_link_event_t event = {0};
+
+    event.type = MCU_LINK_RX_EVENT_TOUCH_EVENT;
+    event.frame.header.msg_class = MCU_FRAME_CLASS_SENSOR;
+    event.frame.header.msg_id = MCU_SENSOR_MSG_TOUCH_EVENT;
+    event.frame.header.payload_len = 6u;
+    event.frame.payload[0] = touch_id;
+    event.frame.payload[1] = (uint8_t)code;
+    write_u32_le(&event.frame.payload[2], timestamp_ms);
+
+    return event;
+}
+
+static void expect_touch(uint8_t touch_id, mcu_touch_event_code_t code, bool active, uint32_t timestamp_ms) {
+    const mcu_link_event_t event = make_touch_event(touch_id, code, timestamp_ms);
+    mcu_touch_state_t state = {0};
+    bool overwrote_latest = true;
+
+    assert(mcu_sensor_service_init() == ESP_OK);
+    assert(mcu_sensor_service_handle_link_event(&event, &overwrote_latest) == ESP_OK);
+    assert(!overwrote_latest);
+    assert(mcu_sensor_service_has_latest_touch());
+    assert(mcu_sensor_service_get_latest_touch(&state) == ESP_OK);
+    assert(state.touch_id == touch_id);
+    assert(state.event_code == code);
+    assert(state.active == active);
+    assert(state.timestamp_ms == timestamp_ms);
+}
+
+static void test_touch_press_is_active(void) {
+    expect_touch(0u, MCU_TOUCH_EVENT_PRESS, true, 123456u);
+}
+
+static void test_touch_release_is_inactive(void) {
+    expect_touch(0u, MCU_TOUCH_EVENT_RELEASE, false, 123789u);
+}
+
+static void test_touch_long_press_is_active(void) {
+    expect_touch(0u, MCU_TOUCH_EVENT_LONG_PRESS, true, 124000u);
+}
+
+int main(void) {
+    const struct {
+        const char *name;
+        void (*fn)(void);
+    } tests[] = {
+        {"touch_press_is_active", test_touch_press_is_active},
+        {"touch_release_is_inactive", test_touch_release_is_inactive},
+        {"touch_long_press_is_active", test_touch_long_press_is_active},
+    };
+    size_t i;
+
+    for (i = 0u; i < ARRAY_SIZE(tests); ++i) {
+        tests[i].fn();
+        printf("[PASS] %s\n", tests[i].name);
+    }
+
+    return 0;
+}

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -80,6 +80,8 @@
 #define WS_START_DISPLAY_SETTLE_MS 150U
 #define CLOUD_RUNTIME_MIN_INTERNAL_FREE_BYTES (24U * 1024U)
 #define CLOUD_RUNTIME_MIN_INTERNAL_LARGEST_BYTES (12U * 1024U)
+#define TOUCH_FONDLE_STATE_ID "fondle_love"
+#define TOUCH_FONDLE_ANIM_ID "fondle_love"
 #if defined(WATCHER_STRESS_BUILD) || defined(CONFIG_WATCHER_STRESS_BUILD)
 #define MCU_LINK_RUNTIME_MAX_EVENTS_PER_TICK 64
 #define MCU_LINK_RUNTIME_TASK_PERIOD_MS 2
@@ -819,9 +821,61 @@ static void maybe_complete_mcu_link_baseline_restore(const mcu_link_event_t *eve
     maybe_log_mcu_obs_state_transition(link, "baseline_restore_done");
 }
 
+static void maybe_handle_touch_behavior_event(const mcu_link_event_t *event, esp_err_t sensor_ret) {
+    mcu_touch_state_t touch = {0};
+    esp_err_t ret;
+
+    if (event == NULL || event->type != MCU_LINK_RX_EVENT_TOUCH_EVENT) {
+        return;
+    }
+
+    if (sensor_ret != ESP_OK) {
+        ESP_LOGW(TAG, "Touch behavior skipped; sensor parse failed: %s", esp_err_to_name(sensor_ret));
+        return;
+    }
+
+    ret = mcu_sensor_service_get_latest_touch(&touch);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Touch behavior skipped; latest touch unavailable: %s", esp_err_to_name(ret));
+        return;
+    }
+
+    if (touch.event_code != MCU_TOUCH_EVENT_PRESS) {
+        return;
+    }
+
+    if (behavior_state_is_action_active()) {
+        ESP_LOGI(TAG, "Touch press skipped while action active touch_id=%u ts=%lu", (unsigned)touch.touch_id,
+                 (unsigned long)touch.timestamp_ms);
+        return;
+    }
+
+    if (behavior_state_is_busy()) {
+        const char *current_state = behavior_state_get_current();
+        ESP_LOGI(TAG, "Touch press skipped while behavior busy state=%s touch_id=%u ts=%lu",
+                 current_state != NULL ? current_state : "<unknown>", (unsigned)touch.touch_id,
+                 (unsigned long)touch.timestamp_ms);
+        return;
+    }
+
+    if (!anim_catalog_has_type(EMOJI_ANIM_FONDLE_LOVE)) {
+        ESP_LOGW(TAG, "Touch press ignored; %s animation is unavailable in SD manifest", TOUCH_FONDLE_ANIM_ID);
+        return;
+    }
+
+    ret = behavior_state_set_with_resources(TOUCH_FONDLE_STATE_ID, "", 0, TOUCH_FONDLE_ANIM_ID, "");
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "Touch press triggered %s touch_id=%u ts=%lu", TOUCH_FONDLE_STATE_ID, (unsigned)touch.touch_id,
+                 (unsigned long)touch.timestamp_ms);
+    } else {
+        ESP_LOGW(TAG, "Touch press failed to trigger %s: %s", TOUCH_FONDLE_STATE_ID, esp_err_to_name(ret));
+    }
+}
+
 static void dispatch_mcu_link_runtime_event(const mcu_link_event_t *event) {
     mcu_link_t *link;
     bool overwrote_latest = false;
+    esp_err_t sensor_ret;
 
     if (event == NULL || event->type == MCU_LINK_RX_EVENT_NONE) {
         return;
@@ -862,7 +916,8 @@ static void dispatch_mcu_link_runtime_event(const mcu_link_event_t *event) {
     (void)mcu_motion_service_handle_link_event(event);
     (void)mcu_led_service_handle_link_event(event);
     (void)mcu_power_service_handle_link_event(event);
-    (void)mcu_sensor_service_handle_link_event(event, &overwrote_latest);
+    sensor_ret = mcu_sensor_service_handle_link_event(event, &overwrote_latest);
+    maybe_handle_touch_behavior_event(event, sensor_ret);
     stress_mode_on_link_event(event);
 
     if (overwrote_latest &&


### PR DESCRIPTION
## 背景
STM32 PR 35 已将 PA4 active-low 触摸输入接入 USART2 runtime，并通过 `TOUCH_EVENT` 上报 `press/release`。ESP32 主线此前只能解析和缓存触摸事件，还没有把 press 转成本地行为反馈。本 PR 接上 ESP32 侧的空闲态 `fondle_love` 响应。

## 本次改动
- 在 `mcu_sensor_service` 中补齐 `touch_id` 与 `event_code`，并定义 `press=1`、`release=2`、`long_press=3` 事件码。
- ESP32 MCU runtime 分发后新增触摸行为处理：仅 `press` 且行为空闲时触发 `fondle_love`。
- `action active` 或 `behavior busy` 时跳过触摸表情，不抢占 TTS、BLE feedback 或动作执行。
- 触发前检查 SD manifest 是否包含 `fondle_love`，缺失时只记录 warning，不影响 MCU link。
- 新增 `mcu_sensor_service` host 测试覆盖 press/release/long_press 解析语义。

## TDD / 验证
- `mcu_sensor_service_host_tests` 通过，覆盖：
  - `code=1` press -> `active=true`
  - `code=2` release -> `active=false`
  - `code=3` long_press -> `active=true`
- `mcu_link_host_tests` 通过。
- `git diff --check` 通过。
- `idf.py build` 通过，生成的动画 manifest 包含 `fondle_love` 和 `fondle_anger`。
- 已实机刷写 `COM37`，ESP32 日志确认 touch press 进入处理逻辑。
- 已将最新 `release/V2.1.0/sdcard/anim` 同步到 SD 卡，确认 `fondle_love.animpack` 和新 `anim_manifest.bin` 存在。

## 文档更新
- 本次不新增文档；STM32 TOUCH_EVENT 字段口径已有交接说明，ESP32 侧实现沿用该协议，并通过 host 测试固化解析语义。

## 风险与注意事项
- 当前策略只在 ESP32 行为空闲时响应 press；busy/action active 期间仅记录 skipped。
- release 不驱动 UI，long_press 只保留协议语义，后续可基于同一事件码扩展长按/双击。
- 实机触摸输入可能产生密集 press/release burst；如果影响体验，建议后续在 ESP32 行为触发处增加节流，或回 STM32 调整 debounce。

## 下一阶段建议
- 插回已同步动画包的 SD 卡后，再抓一次 ESP32 monitor，确认 `Touch press triggered fondle_love` 和实际屏幕动画表现。
- 如产品需要触摸高优先级打断，再单独设计 TTS/action/云端状态抢占策略。
