### PR TITLE
fix: restore STM32 servo output and show handshake failure

### DIFF
--- a/.memory/MEMORY.md
+++ b/.memory/MEMORY.md
@@ -46,6 +46,14 @@ services/  ->  protocols/  ->  hal/  ->  drivers/
    - or `flash-monitor.cmd COM24`
 5. If flashing fails with `Failed to connect to ESP32-S3: No serial data received`, the board likely did not enter bootloader. Try manual `BOOT + RESET`.
 
+## Delivery Gate
+
+- Before committing or opening/updating a PR, review the full diff for correctness and unrelated changes.
+- Before committing or opening/updating a PR, run clang-format check on changed C/C++/header files with the project `.clang-format` rule:
+  - `python C:\Users\50533\.codex\skills\clang-format-check\scripts\check_clang_format.py <changed-source-files>`
+- If clang-format fails and the change is intended for delivery, fix formatting with the same script plus `--fix`, then rerun the check.
+- Keep generated logs and local validation artifacts out of commits unless explicitly requested.
+
 ---
 
 ## Hardware Notes

--- a/firmware/s3/components/protocols/mcu_link/include/mcu_link_bootstrap.h
+++ b/firmware/s3/components/protocols/mcu_link/include/mcu_link_bootstrap.h
@@ -19,6 +19,7 @@ mcu_link_t *mcu_link_bootstrap_get_link(void);
 mcu_link_state_t mcu_link_bootstrap_get_state(void);
 bool mcu_link_bootstrap_is_link_ready(void);
 bool mcu_link_bootstrap_is_ready(void);
+bool mcu_link_bootstrap_handshake_timed_out(uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/firmware/s3/components/protocols/mcu_link/src/mcu_link_bootstrap.c
+++ b/firmware/s3/components/protocols/mcu_link/src/mcu_link_bootstrap.c
@@ -14,11 +14,13 @@ static const int64_t HELLO_RETRY_INTERVAL_US = 1000LL * 1000LL;
 
 static mcu_link_t s_link;
 static bool s_link_initialized;
+static int64_t s_first_hello_req_us;
 static int64_t s_last_hello_req_us;
 
 static esp_err_t mcu_link_bootstrap_send_hello_req(void) {
     uint32_t seq = 0u;
     size_t wire_len = 0u;
+    mcu_link_state_t previous_state = mcu_link_get_state(&s_link);
     esp_err_t ret;
 
     ret = mcu_link_send_hello_req(&s_link, &seq, &wire_len);
@@ -28,6 +30,11 @@ static esp_err_t mcu_link_bootstrap_send_hello_req(void) {
     }
 
     s_last_hello_req_us = esp_timer_get_time();
+    if (s_first_hello_req_us == 0 || (previous_state != MCU_LINK_STATE_HANDSHAKING &&
+                                      previous_state != MCU_LINK_STATE_DEGRADED &&
+                                      previous_state != MCU_LINK_STATE_RECOVERING)) {
+        s_first_hello_req_us = s_last_hello_req_us;
+    }
     ESP_LOGI(TAG, "MCU link hello request queued (seq=%lu wire_len=%u state=%d)", (unsigned long)seq,
              (unsigned)wire_len, (int)mcu_link_get_state(&s_link));
     ESP_LOGI(OBS_TAG, "evt=hello_req seq=%lu msg_class=%u msg_id=%u link_state=%d", (unsigned long)seq,
@@ -86,6 +93,7 @@ esp_err_t mcu_link_bootstrap_init(void) {
     }
 
     s_link_initialized = true;
+    s_first_hello_req_us = 0;
     s_last_hello_req_us = 0;
     ESP_LOGI(TAG, "MCU link bootstrap initialized (uart_ready=%d link_ready=%d ready=%d)",
              mcu_link_uart_is_ready() ? 1 : 0, mcu_link_is_link_ready(&s_link) ? 1 : 0,
@@ -103,6 +111,24 @@ bool mcu_link_bootstrap_is_link_ready(void) {
 
 bool mcu_link_bootstrap_is_ready(void) {
     return s_link_initialized && mcu_link_is_ready(&s_link);
+}
+
+bool mcu_link_bootstrap_handshake_timed_out(uint32_t timeout_ms) {
+    int64_t elapsed_us;
+    mcu_link_state_t state;
+
+    if (!s_link_initialized || s_first_hello_req_us == 0 || timeout_ms == 0) {
+        return false;
+    }
+
+    state = mcu_link_get_state(&s_link);
+    if (state != MCU_LINK_STATE_HANDSHAKING && state != MCU_LINK_STATE_DEGRADED &&
+        state != MCU_LINK_STATE_RECOVERING) {
+        return false;
+    }
+
+    elapsed_us = esp_timer_get_time() - s_first_hello_req_us;
+    return elapsed_us >= ((int64_t)timeout_ms * 1000LL);
 }
 
 esp_err_t mcu_link_bootstrap_poll(mcu_link_event_t *out_event) {

--- a/firmware/s3/components/protocols/mcu_link/src/mcu_link_bootstrap.c
+++ b/firmware/s3/components/protocols/mcu_link/src/mcu_link_bootstrap.c
@@ -30,9 +30,9 @@ static esp_err_t mcu_link_bootstrap_send_hello_req(void) {
     }
 
     s_last_hello_req_us = esp_timer_get_time();
-    if (s_first_hello_req_us == 0 || (previous_state != MCU_LINK_STATE_HANDSHAKING &&
-                                      previous_state != MCU_LINK_STATE_DEGRADED &&
-                                      previous_state != MCU_LINK_STATE_RECOVERING)) {
+    if (s_first_hello_req_us == 0 ||
+        (previous_state != MCU_LINK_STATE_HANDSHAKING && previous_state != MCU_LINK_STATE_DEGRADED &&
+         previous_state != MCU_LINK_STATE_RECOVERING)) {
         s_first_hello_req_us = s_last_hello_req_us;
     }
     ESP_LOGI(TAG, "MCU link hello request queued (seq=%lu wire_len=%u state=%d)", (unsigned long)seq,
@@ -122,8 +122,7 @@ bool mcu_link_bootstrap_handshake_timed_out(uint32_t timeout_ms) {
     }
 
     state = mcu_link_get_state(&s_link);
-    if (state != MCU_LINK_STATE_HANDSHAKING && state != MCU_LINK_STATE_DEGRADED &&
-        state != MCU_LINK_STATE_RECOVERING) {
+    if (state != MCU_LINK_STATE_HANDSHAKING && state != MCU_LINK_STATE_DEGRADED && state != MCU_LINK_STATE_RECOVERING) {
         return false;
     }
 

--- a/firmware/s3/main/app_main.c
+++ b/firmware/s3/main/app_main.c
@@ -80,6 +80,7 @@
 #define WS_START_DISPLAY_SETTLE_MS 150U
 #define CLOUD_RUNTIME_MIN_INTERNAL_FREE_BYTES (24U * 1024U)
 #define CLOUD_RUNTIME_MIN_INTERNAL_LARGEST_BYTES (12U * 1024U)
+#define MCU_HANDSHAKE_UI_TIMEOUT_MS 5000U
 #define TOUCH_FONDLE_STATE_ID "fondle_love"
 #define TOUCH_FONDLE_ANIM_ID "fondle_love"
 #if defined(WATCHER_STRESS_BUILD) || defined(CONFIG_WATCHER_STRESS_BUILD)
@@ -116,6 +117,7 @@ typedef enum {
     IDLE_HINT_WIFI_RECOVERING,
     IDLE_HINT_WIFI_FAILED,
     IDLE_HINT_CLOUD_CONNECTING,
+    IDLE_HINT_STM32_HANDSHAKE_FAILED,
 } idle_hint_mode_t;
 
 typedef struct {
@@ -1227,7 +1229,15 @@ static void wait_for_behavior_idle(uint32_t timeout_ms) {
     }
 }
 
+static bool should_show_stm32_handshake_failure(void) {
+    return mcu_link_bootstrap_handshake_timed_out(MCU_HANDSHAKE_UI_TIMEOUT_MS) && !mcu_link_bootstrap_is_ready();
+}
+
 static idle_hint_mode_t get_idle_hint_mode(void) {
+    if (should_show_stm32_handshake_failure()) {
+        return IDLE_HINT_STM32_HANDSHAKE_FAILED;
+    }
+
     if (ble_service_is_connected()) {
         return IDLE_HINT_BLE_CONNECTED;
     }
@@ -1288,6 +1298,9 @@ static idle_hint_view_t get_idle_hint_view(idle_hint_mode_t mode) {
 
     case IDLE_HINT_CLOUD_CONNECTING:
         return (idle_hint_view_t){.text = "Connecting cloud...", .font_size = 22, .alert = false};
+
+    case IDLE_HINT_STM32_HANDSHAKE_FAILED:
+        return (idle_hint_view_t){.text = "STM32 handshake failed\nServo unavailable", .font_size = 20, .alert = true};
 
     case IDLE_HINT_READY:
     default:

--- a/firmware/s3/sdkconfig.defaults
+++ b/firmware/s3/sdkconfig.defaults
@@ -87,8 +87,8 @@ CONFIG_WATCHER_MCU_LINK_UART_BAUD_RATE=921600
 CONFIG_WATCHER_MCU_LINK_UART_RX_BUFFER=4096
 CONFIG_WATCHER_MCU_LINK_UART_TX_BUFFER=4096
 
-# Keep servo motion output disabled for wake-word bring-up.
-# CONFIG_WATCHER_SERVO_MOTION_ENABLE is not set
+# Keep BLE, Wi-Fi, and behavior servo control routed through the STM32 motion service.
+CONFIG_WATCHER_SERVO_MOTION_ENABLE=y
 
 # Log level
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y


### PR DESCRIPTION
## Background
During DEBUG branch validation, the UI did not surface STM32 handshake failures, and servo control was unavailable through both BLE and Wi-Fi. Investigation showed this was not a BLE- or Wi-Fi-specific path issue. The default configuration had disabled `CONFIG_WATCHER_SERVO_MOTION_ENABLE`, so `hal_servo` only cached angles and did not submit `SERVO_MOVE` commands to the STM32 motion service.

## Changes
- Track the first hello request timestamp for the current `mcu_link_bootstrap` handshake series and expose a handshake timeout helper.
- Add an English idle-screen warning when STM32 handshake remains unavailable: `STM32 handshake failed` / `Servo unavailable`.
- Restore default servo motion output with `CONFIG_WATCHER_SERVO_MOTION_ENABLE=y`, so BLE, Wi-Fi, and behavior-layer servo control route through the STM32 motion service again.
- Add a project memory delivery gate in `.memory/MEMORY.md`: review the full diff before committing or updating a PR, and run clang-format checks on changed C/C++/header files.

## Validation
- `python C:\Users\50533\.codex\skills\clang-format-check\scripts\check_clang_format.py firmware/s3/components/protocols/mcu_link/include/mcu_link_bootstrap.h firmware/s3/components/protocols/mcu_link/src/mcu_link_bootstrap.c firmware/s3/main/app_main.c` passed with clang-format 22.1.4.
- Reviewed the staged diff and confirmed it only contains the delivery-gate memory update plus a clang-format-only adjustment; serial logs were not committed.
- `git diff --check` / `git diff --cached --check` passed.
- `idf.py build` passed and generated `WatcheRobot-S3.bin`; the app partition has about 45% free space remaining.
- `idf.py -p COM37 flash` passed. COM37 was verified as an ESP32-S3, MAC `80:b5:4e:ef:b1:48`.
- Device boot logs confirmed STM32 baseline restore completed with `ready=1`.
- After restoring motion output, behavior servo requests issued before STM32 readiness now enter `MCU_MOTION` and are explicitly rejected instead of being silently cached.

## Documentation
- `sdkconfig.defaults` now documents that servo control is routed through the STM32 motion service.
- `.memory/MEMORY.md` now records the PR delivery gate: review the diff, run clang-format, and keep local logs out of commits.

## Risks And Notes
- Current touch handling switches to the `fondle_love` expression only. `states.json` has an empty `motion` array for `fondle_love`, so touch does not currently drive servo movement. A follow-up motion segment is needed if touch should move the servos.
- `mcu_link_host_tests` could not run in the current Windows shell because no native C compiler was available. ESP-IDF target build plus COM37 device validation covered the main risk for this change.
- Serial validation logs remain local under `firmware/s3/logs/` and were not committed.

## Suggested Follow-Ups
- Add controlled motion segments to the `fondle_love` behavior if touch should drive servo movement.
- Run a BLE/Wi-Fi servo command regression with logs and confirm `Queued SERVO_MOVE`, `Motion ACK`, and `Motion DONE` events.